### PR TITLE
Override SSH username per cloud provider

### DIFF
--- a/yascheduler/clouds/__init__.py
+++ b/yascheduler/clouds/__init__.py
@@ -77,11 +77,13 @@ class AbstractCloudAPI(object):
             ''.join([random.choice(string.ascii_lowercase) for _ in range(8)])
 
     def setup_node(self, ip):
-        ssh_conn.run('apt-get -y update && apt-get -y upgrade', hide=True)
-        ssh_conn.run('apt-get -y install openmpi-bin', hide=True)
         ssh_conn = SSH_Connection(
             host=ip, user=self.ssh_user, connect_kwargs=self.ssh_custom_key
         )
+        sudo_prefix = "" if self.ssh_user == "root" else "sudo "
+        apt_cmd = f"{sudo_prefix}apt-get"
+        ssh_conn.run(f'{apt_cmd} -y update && {apt_cmd} -y upgrade', hide=True)
+        ssh_conn.run(f'{apt_cmd} -y install openmpi-bin', hide=True)
 
         ssh_conn.run('mkdir -p ~/bin', hide=True)
         if self.config.get('local', 'deployable').startswith('http'):

--- a/yascheduler/clouds/__init__.py
+++ b/yascheduler/clouds/__init__.py
@@ -81,7 +81,7 @@ class AbstractCloudAPI(object):
             host=ip, user=self.ssh_user, connect_kwargs=self.ssh_custom_key
         )
         sudo_prefix = "" if self.ssh_user == "root" else "sudo "
-        apt_cmd = f"{sudo_prefix}apt-get"
+        apt_cmd = f"{sudo_prefix}apt-get -o DPkg::Lock::Timeout=600"
         ssh_conn.run(f'{apt_cmd} -y update && {apt_cmd} -y upgrade', hide=True)
         ssh_conn.run(f'{apt_cmd} -y install openmpi-bin', hide=True)
 

--- a/yascheduler/clouds/hetzner.py
+++ b/yascheduler/clouds/hetzner.py
@@ -50,8 +50,9 @@ class HetznerCloudAPI(AbstractCloudAPI):
 
         # warm up
         for _ in range(10):
-            ssh_conn = SSH_Connection(host=ip, user=self.config.get('remote', 'user'),
-                connect_kwargs=self.ssh_custom_key)
+            ssh_conn = SSH_Connection(
+                host=ip, user=self.ssh_user, connect_kwargs=self.ssh_custom_key
+            )
             try: ssh_conn.run('whoami', hide=True)
             except: time.sleep(5)
             else: break

--- a/yascheduler/clouds/upcloud.py
+++ b/yascheduler/clouds/upcloud.py
@@ -22,9 +22,7 @@ class UpCloudAPI(AbstractCloudAPI):
     def init_key(self):
         super().init_key()
         self.login_user = login_user_block(
-            username=self.config.get('remote', 'user'),
-            ssh_keys=[self.public_key],
-            create_password=False
+            username=self.ssh_user, ssh_keys=[self.public_key], create_password=False
         )
 
     def create_node(self):
@@ -47,8 +45,9 @@ class UpCloudAPI(AbstractCloudAPI):
 
         # warm up
         for _ in range(10):
-            ssh_conn = SSH_Connection(host=ip, user=self.config.get('remote', 'user'),
-                connect_kwargs=self.ssh_custom_key)
+            ssh_conn = SSH_Connection(
+                host=ip, user=self.ssh_user, connect_kwargs=self.ssh_custom_key
+            )
             try: ssh_conn.run('whoami', hide=True)
             except: time.sleep(5)
             else: break

--- a/yascheduler/clouds/upcloud.py
+++ b/yascheduler/clouds/upcloud.py
@@ -22,7 +22,9 @@ class UpCloudAPI(AbstractCloudAPI):
     def init_key(self):
         super().init_key()
         self.login_user = login_user_block(
-            username=self.ssh_user, ssh_keys=[self.public_key], create_password=False
+            username=self.ssh_user,
+            ssh_keys=[self.public_key],
+            create_password=False,
         )
 
     def create_node(self):

--- a/yascheduler/data/yascheduler.conf
+++ b/yascheduler/data/yascheduler.conf
@@ -13,6 +13,7 @@ data_dir = /data
 user = root
 
 [clouds]
+az_user = yascheduler
 
 [engine.pcrystal]
 deployable = ~/bin/Pcrystal

--- a/yascheduler/utils.py
+++ b/yascheduler/utils.py
@@ -96,16 +96,23 @@ def check_status():
                 "JOIN yascheduler_nodes AS n ON n.ip=t.ip "
                 "WHERE status=%s AND task_id IN (%s);"
             ),
-            (yac.STATUS_RUNNING, ", ".join([str(task["task_id"]) for task in tasks])),
+            (
+                yac.STATUS_RUNNING,
+                ", ".join([str(task["task_id"]) for task in tasks]),
+            ),
         )
         for row in yac.cursor.fetchall():
-            ssh_user = config.get("clouds", f"{row[4]}", fallback=config.get("remote", "user"))
+            ssh_user = config.get(
+                "clouds", f"{row[4]}", fallback=config.get("remote", "user")
+            )
             print(
                 "." * 50
                 + "ID%s %s at %s@%s:%s"
                 % (row[0], row[1], ssh_user, row[3], row[2]["remote_folder"])
             )
-            ssh_conn = SSH_Connection(host=row[3], user=ssh_user, connect_kwargs=ssh_custom_key)
+            ssh_conn = SSH_Connection(
+                host=row[3], user=ssh_user, connect_kwargs=ssh_custom_key
+            )
             try:
                 result = ssh_conn.run('tail -n15 %s/OUTPUT' % row[2]['remote_folder'], hide=True)
             except UnexpectedExit:


### PR DESCRIPTION
At this time, you cannot specify an SSH username for a specific cloud provider. Some providers assume that the root user is blocked and another user with sudo without a password is used.

This PR allows you to reassign the username. For example:
```ini
;; yascheduler.conf
[remote]
user = root

[clouds]
hetzner_user = yascheduler
```
In this example, the user `yascheduler` will be used for `hetzner` and `root` for the others.
Additionally, `setup_node()` now uses `sudo` if the user is not `root`.

Another slightly off topic change: `apt-get` now waits for the lock file to be released. A couple of times I ran into it, when `apt-get` was already running, and everything crashed.

The code smells a bit, but I tried to keep the changes to a minimum. I tested with hetzner and azure (not released).
