### PR TITLE
Azure cloud provider implementation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 79

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,7 @@ python-daemon
 
 hcloud
 upcloud_api
+azure-identity~=1.7.1
+azure-mgmt-compute~=24.0.1
+azure-mgmt-network~=19.3.0
+azure-mgmt-resource~=20.1.0

--- a/yascheduler/clouds/__init__.py
+++ b/yascheduler/clouds/__init__.py
@@ -111,13 +111,19 @@ class AbstractCloudAPI(object):
                 )
 
     def _run_ssh_cmd_with_backoff(
-        self, host: str, cmd: str, max_time: float = 60, max_wait_time: float = 10
+        self,
+        host: str,
+        cmd: str,
+        max_time: float = 60,
+        max_wait_time: float = 10,
     ):
         "Run ssh command with retries on errors"
 
         def run_cmd():
             ssh_conn = SSH_Connection(
-                host=host, user=self.ssh_user, connect_kwargs=self.ssh_custom_key
+                host=host,
+                user=self.ssh_user,
+                connect_kwargs=self.ssh_custom_key,
             )
             return ssh_conn.run(cmd, hide=True)
 

--- a/yascheduler/clouds/az.py
+++ b/yascheduler/clouds/az.py
@@ -35,7 +35,6 @@ az_vm_param_location = westeurope
 
 import json
 import logging
-import os
 import random
 import string
 from pathlib import Path
@@ -68,11 +67,11 @@ from azure.core.exceptions import HttpResponseError
 from yascheduler.clouds import AbstractCloudAPI
 
 # Azure SDK is too noisy
-for l in [
+for logger_name in [
     "azure.core.pipeline.policies.http_logging_policy",
     "azure.identity._internal.get_token_mixin",
 ]:
-    logging.getLogger(l).setLevel(logging.ERROR)
+    logging.getLogger(logger_name).setLevel(logging.ERROR)
 _log = logging.getLogger(__name__)
 
 

--- a/yascheduler/clouds/az.py
+++ b/yascheduler/clouds/az.py
@@ -157,7 +157,7 @@ class AzureCreatedVMPublicIPNotFoundError(Exception):
 
 class AzureAPI(AbstractCloudAPI):
 
-    name = "az"
+    name = "azure"
     client_id: str
     location: str
     rg_name: str

--- a/yascheduler/clouds/az.py
+++ b/yascheduler/clouds/az.py
@@ -1,0 +1,428 @@
+#!/usr/bin/env python3
+"""
+Azure cloud provider implementation.
+
+Azure setup:
+- Create a dedicated Resource Group:
+  `az group create --location "{location}" --resource-group "{rg_name}"`
+- Create a dedicated application for yascheduler service
+- Assign roles to app in the created Resource Group:
+  ```
+  az role assignment create \
+    --assignee "{client_id}" \
+    --role "{r}" \
+    --resource-group "{rg_name}
+  ```
+
+Configuration in `yascheduler.conf`:
+```
+[clouds]
+; required:
+az_tenant_id = ...
+az_client_id = ...
+az_client_secret = ...
+az_subscription_id = ...
+az_resource_group = ...
+; optional
+az_max_nodes = ...
+az_user = ...
+; optional inputs for infra deployment (example):
+az_infra_param_location = westeurope
+; optinal imputs for VM deployment (example):
+az_vm_param_location = westeurope
+```
+"""
+
+import json
+import logging
+import os
+import random
+import string
+from pathlib import Path
+from typing import cast, Any, Dict, List, NamedTuple, Optional, Union
+
+from configparser import ConfigParser
+from azure.identity import ClientSecretCredential
+from azure.mgmt.compute.v2021_07_01 import ComputeManagementClient
+from azure.mgmt.compute.v2021_07_01.operations import VirtualMachinesOperations
+from azure.mgmt.network.v2021_03_01 import NetworkManagementClient
+from azure.mgmt.network.v2021_03_01.models import PublicIPAddress
+from azure.mgmt.network.v2021_03_01.operations import (
+    PublicIPAddressesOperations,
+    NetworkInterfacesOperations,
+)
+from azure.mgmt.resource.resources.v2021_04_01 import ResourceManagementClient
+from azure.mgmt.resource.resources.v2021_04_01.models import (
+    Dependency,
+    Deployment,
+    DeploymentExtended,
+    DeploymentMode,
+    DeploymentProperties,
+    ResourceGroup,
+)
+from azure.mgmt.resource.resources.v2021_04_01.operations import (
+    DeploymentsOperations,
+)
+from azure.core.exceptions import HttpResponseError
+
+from yascheduler.clouds import AbstractCloudAPI
+
+# Azure SDK is too noisy
+for l in [
+    "azure.core.pipeline.policies.http_logging_policy",
+    "azure.identity._internal.get_token_mixin",
+]:
+    logging.getLogger(l).setLevel(logging.ERROR)
+_log = logging.getLogger(__name__)
+
+
+RG_LOCATION_MISMATCH_TMPL = (
+    "Resource Group '{}' location mismatch: got '{}' instead of '{}'"
+)
+
+DeleteRequestsOperations = Union[
+    DeploymentsOperations,
+    NetworkInterfacesOperations,
+    PublicIPAddressesOperations,
+    VirtualMachinesOperations,
+]
+
+
+class DeleteRequest(NamedTuple):
+    order: int
+    operations: DeleteRequestsOperations
+    name: str
+
+
+class AzureRBACError(Exception):
+    operation: str = "read"
+    resource_type: Optional[str] = None
+
+    def __init__(self, name: str):
+        fstr = "Can't {} {} '{}' - access denied. Please, setup RBAC."
+        msg = fstr.format(
+            self.operation, self.resource_type or "resource", name
+        )
+        super().__init__(msg)
+
+
+class AzureRGReadRBACError(AzureRBACError):
+    operation = "read"
+    resource_type = "Resource Group"
+
+
+class AzurePIPReadRBACError(AzureRBACError):
+    operation = "read"
+    resource_type = "Public IP Address"
+
+
+class AzureDeploymentCreateRBACError(AzureRBACError):
+    operation = "create"
+    resuource_type = "Deployment"
+
+
+class AzureNotFoundError(Exception):
+    resource_type: Optional[str] = None
+
+    def __init__(self, name: str):
+        fstr = "{} '{}' - not found."
+        msg = fstr.format(self.resource_type or "Resource", name)
+        super().__init__(msg)
+
+
+class AzureRGNotFoundError(AzureNotFoundError):
+    resource_type = "Resource Group"
+
+
+class AzurePIPNotFoundError(AzureNotFoundError):
+    resource_type = "Public IP Address"
+
+
+class AzureCreateError(Exception):
+    resource_type: Optional[str] = None
+
+    def __init__(self, name: str):
+        fstr = "{} '{}' failed to create."
+        msg = fstr.format(self.resource_type or "Resource", name)
+        super().__init__(msg)
+
+
+class AzureDeploymentCreateError(AzureCreateError):
+    resource_type = "Deployment"
+
+
+class AzureCreatedVMPublicIPNotFoundError(Exception):
+    def __init__(self):
+        super().__init__("VM created without IP in outputs")
+
+
+class AzureAPI(AbstractCloudAPI):
+
+    name = "az"
+    client_id: str
+    location: str
+    rg_name: str
+    resource_client: ResourceManagementClient
+    network_client: NetworkManagementClient
+    compute_client: ComputeManagementClient
+    infra_tmpl_path: Path
+    infra_deployment_name_tmpl: str = "{}-infra-deployment"
+    vm_tmpl_path: Path
+    vm_deployment_name_tmpl: str = "{}-vm-{}-deployment"
+
+    def __init__(self, config: ConfigParser):
+        super().__init__(
+            max_nodes=config.getint("clouds", "az_max_nodes", fallback=None)
+        )
+        self.config = config
+        self.client_id = config.get("clouds", "az_client_id")
+        self.location = config.get(
+            "clouds", "az_location", fallback="westeurope"
+        )
+        self.rg_name = config.get(
+            "clouds", "az_resource_group_name", fallback="YaScheduler-VM-rg"
+        )
+        self.infra_tmpl_path = Path(
+            config.get(
+                "clouds",
+                "az_infra_tmpl_path",
+                fallback=Path(__file__).parent.absolute()
+                / Path("azure_infra_tmpl.json"),
+            )
+        )
+        self.vm_tmpl_path = Path(
+            config.get(
+                "clouds",
+                "az_vm_tmpl_path",
+                fallback=Path(__file__).parent.absolute()
+                / Path("azure_vm_tmpl.json"),
+            )
+        )
+        credential = ClientSecretCredential(
+            tenant_id=config.get("clouds", "az_tenant_id"),
+            client_id=self.client_id,
+            client_secret=config.get("clouds", "az_client_secret"),
+        )
+        subscription_id = config.get("clouds", "az_subscription_id")
+        self.resource_client = ResourceManagementClient(
+            credential,
+            subscription_id,
+            api_version="2021-04-01",
+        )
+        self.network_client = NetworkManagementClient(
+            credential, subscription_id
+        )
+        self.compute_client = ComputeManagementClient(
+            credential, subscription_id
+        )
+
+    @property
+    def ssh_user(self) -> str:
+        "Default SSH user for azure"
+        ssh_user = super().ssh_user
+        if ssh_user == "root":
+            _log.warn("Root user not supported on Azure")
+            ssh_user = "yascheduler"
+        return ssh_user
+
+    @property
+    def cloud_config_data(self) -> Dict[str, Any]:
+        "cloud-config for azure"
+        my_boot_cmds = [
+            # see https://github.com/MicrosoftDocs/azure-docs/issues/82500
+            "systemctl mask waagent-apt.service",
+        ]
+        data = super().cloud_config_data
+        data["bootcmd"] = my_boot_cmds + data.get("bootcmd", [])
+        return data
+
+    def _get_conf_by_prefix(self, section: str, prefix: str) -> Dict[str, str]:
+        "Get part of config by section and prefix as dict"
+        filtered = filter(
+            lambda x: x[0].startswith(prefix), self.config.items(section)
+        )
+        prefix_removed = map(
+            lambda x: (x[0].removeprefix(prefix), x[1]), filtered
+        )
+        return dict(prefix_removed)
+
+    def get_rg(self) -> ResourceGroup:
+        "Check Resource Group"
+        try:
+            rg_result = self.resource_client.resource_groups.get(self.rg_name)
+            if self.location != rg_result.location:
+                msg = RG_LOCATION_MISMATCH_TMPL.format(
+                    self.rg_name, rg_result.location, self.location
+                )
+                _log.warning(msg)
+            return rg_result
+        except HttpResponseError as e:
+            code = getattr(e, "error", None) and getattr(e.error, "code", None)
+            if code == "AuthorizationFailed":
+                raise AzureRGReadRBACError(self.rg_name) from e
+            if code == "ResourceGroupNotFound":
+                raise AzureRGNotFoundError(self.rg_name) from e
+            raise e
+
+    def get_pip(self, name: str) -> PublicIPAddress:
+        "Get Public IP Address by name"
+        try:
+            return self.network_client.public_ip_addresses.get(
+                self.rg_name, name
+            )
+        except HttpResponseError as e:
+            code = getattr(e, "error", None) and getattr(e.error, "code", None)
+            if code == "AuthorizationFailed":
+                raise AzurePIPReadRBACError(name) from e
+            raise AzurePIPNotFoundError(name) from e
+
+    def create_deployment(
+        self, name: str, tmpl: object, params: Dict[str, Any]
+    ) -> DeploymentExtended:
+        "Create deployment"
+        properties = DeploymentProperties(
+            mode=DeploymentMode.incremental,
+            template=tmpl,
+            parameters={k: {"value": v} for k, v in params.items()},
+        )
+        try:
+            res = self.resource_client.deployments.begin_create_or_update(
+                resource_group_name=self.rg_name,
+                deployment_name=name,
+                parameters=Deployment(properties=properties),
+            ).result()
+            _log.info(f"Deployment {name} created/updated")
+            return res
+        except HttpResponseError as e:
+            code = getattr(e, "error", None) and getattr(e.error, "code", None)
+            if code == "AuthorizationFailed":
+                raise AzureDeploymentCreateRBACError(name) from e
+            raise AzureDeploymentCreateError(name) from e
+
+    def create_infra_deployment(self) -> Dict[str, Any]:
+        "Create deployment with common infrastructure parts"
+        params = self._get_conf_by_prefix("clouds", "az_infra_param_")
+        name = self.infra_deployment_name_tmpl.format(self.rg_name)
+        with open(self.infra_tmpl_path, "r") as fd:
+            tmpl = json.load(fd)
+        res = self.create_deployment(name, tmpl, params)
+        return res.properties and res.properties.outputs or {}
+
+    def create_vm_deployment(self, infra_outputs) -> Dict[str, Any]:
+        "Create deployment with VM parts"
+        rnd_id = "".join(
+            [random.choice(string.ascii_lowercase) for _ in range(8)]
+        )
+        name = self.vm_deployment_name_tmpl.format(self.rg_name, rnd_id)
+        params = {
+            "namePrefix": rnd_id,
+            "adminPublicKey": self.public_key,
+            "customData": "#cloud-config\n"
+            + json.dumps(self.cloud_config_data),
+        }
+        # inherit params from infra deployment outputs
+        inherit_infra_params = [
+            "projectName",
+            "location",
+            "networkSecurityGroupName",
+            "virtualNetworkName",
+            "subnetName",
+        ]
+        for k, v in infra_outputs.items():
+            if k in inherit_infra_params and type(v) == dict:
+                params[k] = v.get("value")
+        # load from config
+        params.update(self._get_conf_by_prefix("clouds", "az_vm_param_"))
+
+        with open(self.vm_tmpl_path, "r") as fd:
+            tmpl = json.load(fd)
+        res = self.create_deployment(name, tmpl, params)
+        return res.properties and res.properties.outputs or {}
+
+    def create_node(self):
+        infra_outputs = self.create_infra_deployment()
+        vm_outputs = self.create_vm_deployment(infra_outputs)
+
+        ip_name: str | None = vm_outputs.get("publicIpAddressName", {}).get(
+            "value"
+        )
+        if not ip_name:
+            raise AzureCreatedVMPublicIPNotFoundError()
+        ip_address = self.get_pip(ip_name).ip_address
+        if not ip_address:
+            raise AzureCreatedVMPublicIPNotFoundError()
+
+        # wait node up and ready
+        self._run_ssh_cmd_with_backoff(
+            ip_address, cmd="cloud-init status --wait", max_wait_time=600
+        )
+
+        return ip_address
+
+    def _run_del_reqs(self, reqs: List[DeleteRequest]) -> None:
+        for req in sorted(reqs, key=lambda x: x[0]):
+            _log.info(f"Removing {req.name}...")
+            try:
+                req.operations.begin_delete(self.rg_name, req.name).result()
+                _log.info(f"{req.name} removed")
+            except Exception as e:
+                _log.info(f"Can't remove {req.name}: {str(e)}")
+
+    def delete_node(self, ip):
+        del_reqs: List[DeleteRequest] = []
+
+        # find Public IP Address
+        pip_obj = None
+        for i in self.network_client.public_ip_addresses.list(self.rg_name):
+            i = cast(PublicIPAddress, i)
+            if i.ip_address != ip:
+                continue
+            pip_obj = i
+            req = DeleteRequest(
+                99, self.network_client.public_ip_addresses, cast(str, i.name)
+            )
+            del_reqs.append(req)
+
+        if not pip_obj:
+            _log.error(f"Public IP {ip} not found")
+            return
+        pip_tags = cast(Dict[str, str], pip_obj.tags) or {}
+
+        # find Deployment
+        deployment_id = pip_tags.get("DeploymentId")
+        if not deployment_id:
+            _log.error("Deployment ID not found in Public IP tags")
+            return self._run_del_reqs(del_reqs)
+
+        deployment_name = self.vm_deployment_name_tmpl.format(
+            self.rg_name, deployment_id
+        )
+        try:
+            deployment = self.resource_client.deployments.get(
+                self.rg_name, deployment_name
+            )
+            req = DeleteRequest(
+                99, self.resource_client.deployments, deployment_name
+            )
+            del_reqs.append(req)
+        except Exception as e:
+            _log.error(f"Can't get deployment {deployment_name}: {str(e)}")
+            return self._run_del_reqs(del_reqs)
+
+        deps = (
+            cast(
+                Union[List[Dependency], None],
+                deployment.properties and deployment.properties.dependencies,
+            )
+            or []
+        )
+        for d in deps:
+            if not d.resource_name:
+                continue
+            if d.resource_type == "Microsoft.Compute/virtualMachines":
+                op = self.compute_client.virtual_machines
+                del_reqs.append(DeleteRequest(0, op, d.resource_name))
+            if d.resource_type == "Microsoft.Network/networkInterfaces":
+                op = self.network_client.network_interfaces
+                del_reqs.append(DeleteRequest(1, op, d.resource_name))
+        return self._run_del_reqs(del_reqs)

--- a/yascheduler/clouds/az.py
+++ b/yascheduler/clouds/az.py
@@ -110,7 +110,7 @@ class AzureRGReadRBACError(AzureRBACError):
     resource_type = "Resource Group"
 
 
-class AzurePIPReadRBACError(AzureRBACError):
+class AzurePubIPReadRBACError(AzureRBACError):
     operation = "read"
     resource_type = "Public IP Address"
 
@@ -133,7 +133,7 @@ class AzureRGNotFoundError(AzureNotFoundError):
     resource_type = "Resource Group"
 
 
-class AzurePIPNotFoundError(AzureNotFoundError):
+class AzurePubIPNotFoundError(AzureNotFoundError):
     resource_type = "Public IP Address"
 
 
@@ -272,8 +272,8 @@ class AzureAPI(AbstractCloudAPI):
         except HttpResponseError as e:
             code = getattr(e, "error", None) and getattr(e.error, "code", None)
             if code == "AuthorizationFailed":
-                raise AzurePIPReadRBACError(name) from e
-            raise AzurePIPNotFoundError(name) from e
+                raise AzurePubIPReadRBACError(name) from e
+            raise AzurePubIPNotFoundError(name) from e
 
     def create_deployment(
         self, name: str, tmpl: object, params: Dict[str, Any]

--- a/yascheduler/clouds/azure_infra_tmpl.json
+++ b/yascheduler/clouds/azure_infra_tmpl.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "projectName": {
+      "type": "string",
+      "defaultValue": "yascheduler",
+      "minLength": 3,
+      "maxLength": 11,
+      "metadata": {
+        "description": "Specify a project name that is used to generate resource names."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Specify a location for the resources."
+      }
+    },
+    "resourceTags": {
+      "type": "object",
+      "defaultValue": {
+        "ProjectName": "[parameters('projectName')]"
+      }
+    },
+
+    "virtualNetworkName": {
+      "type": "string",
+      "defaultValue": "[concat(parameters('projectName'), '-vnet')]"
+    },
+    "subnetAddress": {
+      "type": "string",
+      "defaultValue": "10.0.0.0"
+    },
+    "subnetMask": {
+      "type": "int",
+      "minValue": 0,
+      "maxValue": 32,
+      "defaultValue": 24
+    },
+    "subnetName": {
+      "type": "string",
+      "defaultValue": "[concat(parameters('projectName'), '-subnet')]"
+    },
+
+    "networkSecurityGroupName": {
+      "type": "string",
+      "defaultValue": "[concat(parameters('projectName'), '-nsg')]"
+    },
+    "networkSecurityGroupRules": {
+      "type": "array",
+      "defaultValue": [
+        {
+          "name": "SSH",
+          "properties": {
+            "priority": 300,
+            "protocol": "TCP",
+            "access": "Allow",
+            "direction": "Inbound",
+            "sourceAddressPrefix": "*",
+            "sourcePortRange": "*",
+            "destinationAddressPrefix": "*",
+            "destinationPortRange": "22"
+          }
+        }
+      ],
+      "metadata": {
+        "description": "Specifies security group users. By default, allow SSH."
+      }
+    }
+  },
+  "variables": {
+    "addressPrefix": "[concat(parameters('subnetAddress'), '/', parameters('subnetMask'))]"
+  },
+  "resources": [
+    {
+      "name": "[parameters('networkSecurityGroupName')]",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2021-05-01",
+      "location": "[parameters('location')]",
+      "tags": "[parameters('resourceTags')]",
+      "properties": {
+        "securityRules": "[parameters('networkSecurityGroupRules')]"
+      }
+    },
+    {
+      "name": "[parameters('virtualNetworkName')]",
+      "type": "Microsoft.Network/VirtualNetworks",
+      "apiVersion": "2021-01-01",
+      "location": "[parameters('location')]",
+      "dependsOn": [],
+      "tags": "[parameters('resourceTags')]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": ["[variables('addressPrefix')]"]
+        },
+        "subnets": [
+          {
+            "name": "[parameters('subnetName')]",
+            "properties": {
+              "addressPrefix": "[variables('addressPrefix')]"
+            }
+          }
+        ],
+        "enableDdosProtection": false
+      }
+    }
+  ],
+  "outputs": {
+    "projectName": {
+      "type": "string",
+      "value": "[parameters('projectName')]"
+    },
+    "location": {
+      "type": "string",
+      "value": "[parameters('location')]"
+    },
+    "resourceTags": {
+      "type": "object",
+      "value": "[parameters('resourceTags')]"
+    },
+    "networkSecurityGroupName": {
+      "type": "string",
+      "value": "[parameters('networkSecurityGroupName')]"
+    },
+    "virtualNetworkName": {
+      "type": "string",
+      "value": "[parameters('virtualNetworkName')]"
+    },
+    "subnetName": {
+      "type": "string",
+      "value": "[parameters('subnetName')]"
+    }
+  }
+}

--- a/yascheduler/clouds/azure_vm_tmpl.json
+++ b/yascheduler/clouds/azure_vm_tmpl.json
@@ -1,0 +1,222 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "projectName": {
+      "type": "string",
+      "defaultValue": "yascheduler",
+      "minLength": 3,
+      "maxLength": 11,
+      "metadata": {
+        "description": "Specify a project name that is used to generate resource names."
+      }
+    },
+    "namePrefix": {
+      "type": "string",
+      "defaultValue": "[uniqueString(resourceGroup().id)]"
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Specify a location for the resources."
+      }
+    },
+    "resourceTags": {
+      "type": "object",
+      "defaultValue": {
+        "ProjectName": "[parameters('projectName')]",
+        "DeploymentId": "[parameters('namePrefix')]"
+      }
+    },
+
+    "publicIpAddressName": {
+      "type": "string",
+      "defaultValue": "[format('{0}-{1}-ip', parameters('projectName'), parameters('namePrefix'))]"
+    },
+    "publicIpAddressType": {
+      "type": "string",
+      "defaultValue": "Dynamic"
+    },
+    "publicIpAddressSku": {
+      "type": "string",
+      "defaultValue": "Basic"
+    },
+
+    "networkSecurityGroupName": {
+      "type": "string",
+      "defaultValue": "[concat(parameters('projectName'), '-nsg')]"
+    },
+    "virtualNetworkName": {
+      "type": "string",
+      "defaultValue": "[concat(parameters('projectName'), '-vnet')]"
+    },
+    "subnetName": {
+      "type": "string",
+      "defaultValue": "[concat(parameters('projectName'), '-subnet')]"
+    },
+    "networkInterfaceName": {
+      "type": "string",
+      "defaultValue": "[format('{0}-{1}-nic', parameters('projectName'), parameters('namePrefix'))]"
+    },
+
+    "virtualMachineName": {
+      "type": "string",
+      "defaultValue": "[format('{0}-{1}-vm', parameters('projectName'), parameters('namePrefix'))]"
+    },
+    "virtualMachineComputerName": {
+      "type": "string",
+      "defaultValue": "[parameters('virtualMachineName')]"
+    },
+    "virtualMachineSize": {
+      "type": "string",
+      "defaultValue": "Standard_B1s"
+    },
+    "osDiskType": {
+      "type": "string",
+      "defaultValue": "StandardSSD_LRS"
+    },
+    "imagePublisher": {
+      "type": "string",
+      "defaultValue": "debian"
+    },
+    "imageOffer": {
+      "type": "string",
+      "defaultValue": "debian-10"
+    },
+    "imageSku": {
+      "type": "string",
+      "defaultValue": "10-backports-gen2"
+    },
+    "imageVersion": {
+      "type": "string",
+      "defaultValue": "latest"
+    },
+    "adminUsername": {
+      "type": "string",
+      "defaultValue": "yascheduler"
+    },
+    "adminPublicKey": {
+      "type": "string"
+    },
+    "customData": {
+      "type": "string",
+      "defaultValue": null
+    }
+  },
+  "variables": {
+    "ipId": "[resourceId(resourceGroup().name, 'Microsoft.Network/publicIpAddresses', parameters('publicIpAddressName'))]",
+    "nsgId": "[resourceId(resourceGroup().name, 'Microsoft.Network/networkSecurityGroups', parameters('networkSecurityGroupName'))]",
+    "vnetId": "[resourceId(resourceGroup().name, 'Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]",
+    "subnetRef": "[concat(variables('vnetId'), '/subnets/', parameters('subnetName'))]",
+    "nicId": "[resourceId(resourceGroup().name, 'Microsoft.Network/networkInterfaces', parameters('networkInterfaceName'))]",
+    "imageReference": {
+      "publisher": "[parameters('imagePublisher')]",
+      "offer": "[parameters('imageOffer')]",
+      "sku": "[parameters('imageSku')]",
+      "version": "[parameters('imageVersion')]"
+    },
+    "linuxConfiguration": {
+      "disablePasswordAuthentication": true,
+      "ssh": {
+        "publicKeys": [
+          {
+            "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
+            "keyData": "[parameters('adminPublicKey')]"
+          }
+        ]
+      }
+    }
+  },
+  "resources": [
+    {
+      "name": "[parameters('publicIpAddressName')]",
+      "type": "Microsoft.Network/publicIpAddresses",
+      "apiVersion": "2019-02-01",
+      "location": "[parameters('location')]",
+      "tags": "[parameters('resourceTags')]",
+      "properties": {
+        "publicIpAllocationMethod": "[parameters('publicIpAddressType')]",
+        "deleteOption": "Delete"
+      },
+      "sku": {
+        "name": "[parameters('publicIpAddressSku')]"
+      }
+    },
+    {
+      "name": "[parameters('networkInterfaceName')]",
+      "type": "Microsoft.Network/networkInterfaces",
+      "apiVersion": "2021-03-01",
+      "location": "[parameters('location')]",
+      "tags": "[parameters('resourceTags')]",
+      "dependsOn": ["[variables('ipId')]"],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "subnet": {
+                "id": "[variables('subnetRef')]"
+              },
+              "privateIPAllocationMethod": "Dynamic",
+              "publicIpAddress": {
+                "id": "[variables('ipId')]"
+              }
+            }
+          }
+        ],
+        "networkSecurityGroup": {
+          "id": "[variables('nsgId')]"
+        },
+        "deleteOption": "Delete"
+      }
+    },
+    {
+      "name": "[parameters('virtualMachineName')]",
+      "type": "Microsoft.Compute/virtualMachines",
+      "apiVersion": "2021-07-01",
+      "location": "[parameters('location')]",
+      "tags": "[parameters('resourceTags')]",
+      "dependsOn": ["[variables('nicId')]"],
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('virtualMachineSize')]"
+        },
+        "storageProfile": {
+          "osDisk": {
+            "createOption": "fromImage",
+            "deleteOption": "Delete",
+            "managedDisk": {
+              "storageAccountType": "[parameters('osDiskType')]"
+            }
+          },
+          "imageReference": "[variables('imageReference')]"
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[variables('nicId')]"
+            }
+          ]
+        },
+        "osProfile": {
+          "computerName": "[parameters('virtualMachineComputerName')]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "linuxConfiguration": "[variables('linuxConfiguration')]",
+          "customData": "[base64(parameters('customData'))]"
+        },
+        "diagnosticsProfile": {
+          "bootDiagnostics": {
+            "enabled": true
+          }
+        }
+      }
+    }
+  ],
+  "outputs": {
+    "publicIpAddressName": {
+      "type": "string",
+      "value": "[parameters('publicIpAddressName')]"
+    }
+  }
+}


### PR DESCRIPTION
The `AbstractCloudAPI` is extended by the `cloud_config_data` property. This is a generic `cloud-config` that can be extended for each provider.
New internal methods have been added to `AbstractCloudAPI` to wait for SSH command execution, with repeating when an exception occurs. This helps to wait for SSH service activation and `cloud-init` (or something else) completion when creating a node.

`AbstractCloudAPI` implemented for `Azure` as `AzureAPI` class.
Azure is a little different: it requires the creation of many objects to allocate a single node. Then, de-allocation of a node also requires removing many objects. `Deployment` objects are used to create a node. One to create common objects (`Network Security Group`, `Virtual Network`, `Subnet`) and one to create node-specific objects (`Virtual Machine`, `OS Disk`, `Network Interface`, `Public IP Address`).

```mermaid
flowchart TD
    subgraph RG[Resource Group]
        direction TB
        subgraph INFRA[infra deployment]
            NSG[Network Security Group]
            SN[Subnet]
            VN[Virtual Network]
            SN --> VN
        end

        subgraph Node[vm deployment]
            NIC[Network Interface]
            PIP[Public IP]
            VM[Virtual Machine]  
            OSDisk[OS Disk]
            VM --> OSDisk
        end
        
        VM --> NIC --> PIP & SN & NSG
    end
```

When objects of a node are created, they are tagged with a random string ID.  Then, when it's time to remove a node, we look for `Public IP Address` (because we don't have any other node ID). In the `Public IP Address` object there is a tag, by the tag there is a `Deployment` object. `Network Interface` and `Virtual Machine` are related to `Deployment`. Accordingly, it remains to delete them in the correct order. The `OS Disk` is automatically deleted.

The `Deployment` templates are described in separate JSON files. `Deployment` has inputs and outputs. The inputs can be specified via config. The outputs of the first `Deployment` are fed to the inputs of the second one.

The `cloud-config` is used to provision the nodes.

Technical Debt:
Exception handling needs to be formalized.
Some other node ID instead of IP address is needed.
It is necessary to record the reference of all objects created in the cloud. Not just for Azure, but for all providers. This will allow deleting or modifying them without a fragile search.




