### PR TITLE
feat(hetzner): simple cloud-init support

### DIFF
--- a/yascheduler/clouds/__init__.py
+++ b/yascheduler/clouds/__init__.py
@@ -93,7 +93,7 @@ class AbstractCloudAPI(object):
         self,
         fn: Callable[[], T],
         max_time: float = 60,
-        max_wait_interval: float = 10,
+        max_interval: float = 10,
     ) -> T:
         "Retry with random backoff"
         end_time = datetime.now() + timedelta(seconds=max_time)
@@ -105,7 +105,7 @@ class AbstractCloudAPI(object):
                     raise e
                 sleep(
                     min(
-                        random.random() * max_wait_interval,
+                        random.random() * max_interval,
                         max(0, (datetime.now() - end_time).total_seconds()),
                     )
                 )
@@ -115,7 +115,7 @@ class AbstractCloudAPI(object):
         host: str,
         cmd: str,
         max_time: float = 60,
-        max_wait_time: float = 10,
+        max_interval: float = 10,
     ):
         "Run ssh command with retries on errors"
 
@@ -127,7 +127,7 @@ class AbstractCloudAPI(object):
             )
             return ssh_conn.run(cmd, hide=True)
 
-        return self._retry_with_backoff(run_cmd, max_time, max_wait_time)
+        return self._retry_with_backoff(run_cmd, max_time, max_interval)
 
     def setup_node(self, ip):
         ssh_conn = SSH_Connection(

--- a/yascheduler/clouds/az.py
+++ b/yascheduler/clouds/az.py
@@ -354,7 +354,7 @@ class AzureAPI(AbstractCloudAPI):
 
         # wait node up and ready
         self._run_ssh_cmd_with_backoff(
-            ip_address, cmd="cloud-init status --wait", max_wait_time=600
+            ip_address, cmd="cloud-init status --wait", max_time=600
         )
 
         return ip_address

--- a/yascheduler/clouds/hetzner.py
+++ b/yascheduler/clouds/hetzner.py
@@ -1,13 +1,11 @@
 
-import time
+import json
 import logging
 
 from hcloud import Client, APIException
 from hcloud.images.domain import Image
 from hcloud.server_types.domain import ServerType
 from hcloud.ssh_keys.domain import SSHKey
-
-from fabric import Connection as SSH_Connection
 
 from yascheduler.clouds import AbstractCloudAPI
 
@@ -40,22 +38,17 @@ class HetznerCloudAPI(AbstractCloudAPI):
         response = self.client.servers.create(
             name=self.get_rnd_name('node'),
             server_type=ServerType('cx51'), image=Image(name='debian-10'),
-            ssh_keys=[SSHKey(name=self.key_name)]
+            ssh_keys=[SSHKey(name=self.key_name)],
+            user_data="#cloud-config\n" + json.dumps(self.cloud_config_data),
         )
         server = response.server
         ip = server.public_net.ipv4.ip
         logging.info('CREATED %s' % ip)
 
-        time.sleep(5)
-
-        # warm up
-        for _ in range(10):
-            ssh_conn = SSH_Connection(
-                host=ip, user=self.ssh_user, connect_kwargs=self.ssh_custom_key
-            )
-            try: ssh_conn.run('whoami', hide=True)
-            except: time.sleep(5)
-            else: break
+        # wait node up and ready
+        self._run_ssh_cmd_with_backoff(
+            ip, cmd="cloud-init status --wait", max_wait_time=600
+        )
 
         return ip
 

--- a/yascheduler/clouds/hetzner.py
+++ b/yascheduler/clouds/hetzner.py
@@ -47,7 +47,7 @@ class HetznerCloudAPI(AbstractCloudAPI):
 
         # wait node up and ready
         self._run_ssh_cmd_with_backoff(
-            ip, cmd="cloud-init status --wait", max_wait_time=600
+            ip, cmd="cloud-init status --wait", max_interval=5
         )
 
         return ip


### PR DESCRIPTION
`cloud-init` support, similar to the `azure` provider. Just pass cloud-config content as "user data". Then wait `cloud-init` to finish.