### PR TITLE
Revert "fix: wrong name (az->azure)"

### DIFF
--- a/yascheduler/clouds/az.py
+++ b/yascheduler/clouds/az.py
@@ -157,7 +157,7 @@ class AzureCreatedVMPublicIPNotFoundError(Exception):
 
 class AzureAPI(AbstractCloudAPI):
 
-    name = "azure"
+    name = "az"
     client_id: str
     location: str
     rg_name: str


### PR DESCRIPTION
This reverts commit 48f1de627b12b60b3fb07340a864631286cb62e4.

The renaming idea was bad because the `name` field is used as a key:
https://github.com/tilde-lab/yascheduler/blob/master/yascheduler/clouds/__init__.py#L182