### PR TITLE
File paths from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ result = yac.queue_submit_task(label, {'fort.34': struct_input, 'INPUT': setup_i
 print(result)
 ```
 
+File paths can be set using environment variables:
+
+|                    | Environment variable    | Default                             |
+|--------------------|-------------------------|-------------------------------------|
+| Configuration file | `YASCHEDULER_CONF_PATH` | `/etc/yascheduler/yascheduler.conf` |
+| Log file path      | `YASCHEDULER_LOG_PATH`  | `/var/log/yascheduler.log`          |
+| PID file           | `YASCHEDULER_PID_PATH`  | `/var/run/yascheduler.pid`          |
 
 AiiDA integration
 ------------

--- a/yascheduler/__init__.py
+++ b/yascheduler/__init__.py
@@ -1,9 +1,12 @@
+from os import getenv
 
 __version__ = "0.5.0"
 
-CONFIG_FILE = '/etc/yascheduler/yascheduler.conf'
-LOG_FILE = '/var/log/yascheduler.log'
-PID_FILE = '/var/run/yascheduler.pid'
+CONFIG_FILE = getenv(
+    "YASCHEDULER_CONF_PATH", "/etc/yascheduler/yascheduler.conf"
+)
+LOG_FILE = getenv("YASCHEDULER_LOG_PATH", '/var/log/yascheduler.log')
+PID_FILE = getenv("YASCHEDULER_PID_PATH", '/var/run/yascheduler.pid')
 SLEEP_INTERVAL = 6
 N_IDLE_PASSES = 20
 DEFAULT_NODES_PER_PROVIDER = 10


### PR DESCRIPTION
Currently, file paths to config/log/pid are hard-coded to the system paths. So, a user without root rights can't run client or server. This PR adds the ability to override these paths with environment variables.
The default behavior is not changed.
