### PR TITLE
fix: azure api versions

### DIFF
--- a/yascheduler/clouds/az.py
+++ b/yascheduler/clouds/az.py
@@ -45,9 +45,9 @@ from configparser import ConfigParser
 from azure.identity import ClientSecretCredential
 from azure.mgmt.compute.v2021_07_01 import ComputeManagementClient
 from azure.mgmt.compute.v2021_07_01.operations import VirtualMachinesOperations
-from azure.mgmt.network.v2021_03_01 import NetworkManagementClient
-from azure.mgmt.network.v2021_03_01.models import PublicIPAddress
-from azure.mgmt.network.v2021_03_01.operations import (
+from azure.mgmt.network.v2020_06_01 import NetworkManagementClient
+from azure.mgmt.network.v2020_06_01.models import PublicIPAddress
+from azure.mgmt.network.v2020_06_01.operations import (
     PublicIPAddressesOperations,
     NetworkInterfacesOperations,
 )

--- a/yascheduler/clouds/azure_infra_tmpl.json
+++ b/yascheduler/clouds/azure_infra_tmpl.json
@@ -77,7 +77,7 @@
     {
       "name": "[parameters('networkSecurityGroupName')]",
       "type": "Microsoft.Network/networkSecurityGroups",
-      "apiVersion": "2021-05-01",
+      "apiVersion": "2020-06-01",
       "location": "[parameters('location')]",
       "tags": "[parameters('resourceTags')]",
       "properties": {
@@ -87,7 +87,7 @@
     {
       "name": "[parameters('virtualNetworkName')]",
       "type": "Microsoft.Network/VirtualNetworks",
-      "apiVersion": "2021-01-01",
+      "apiVersion": "2020-06-01",
       "location": "[parameters('location')]",
       "dependsOn": [],
       "tags": "[parameters('resourceTags')]",

--- a/yascheduler/clouds/azure_vm_tmpl.json
+++ b/yascheduler/clouds/azure_vm_tmpl.json
@@ -132,7 +132,7 @@
     {
       "name": "[parameters('publicIpAddressName')]",
       "type": "Microsoft.Network/publicIpAddresses",
-      "apiVersion": "2019-02-01",
+      "apiVersion": "2020-06-01",
       "location": "[parameters('location')]",
       "tags": "[parameters('resourceTags')]",
       "properties": {
@@ -146,7 +146,7 @@
     {
       "name": "[parameters('networkInterfaceName')]",
       "type": "Microsoft.Network/networkInterfaces",
-      "apiVersion": "2021-03-01",
+      "apiVersion": "2020-06-01",
       "location": "[parameters('location')]",
       "tags": "[parameters('resourceTags')]",
       "dependsOn": ["[variables('ipId')]"],


### PR DESCRIPTION
Close #24 
Look's like some Azure API versions are ephemeral. So, version `v2021-03-01` of network API is [removed](https://github.com/Azure/azure-sdk-for-python/commit/e7ae4e0535093479e0964a9330809edb2ff20c40) between minor `19.x.x` versions of the `azure-mgmt-network` package.
Now I only use the versions mentioned in the [reference](https://docs.microsoft.com/en-us/python/api/overview/azure/?view=azure-python).