### PR TITLE
Feature: Webhooks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ pg8000
 paramiko~=2.10.1
 fabric
 python-daemon
+requests>=2.21
 
 hcloud
 upcloud_api

--- a/yascheduler/__init__.py
+++ b/yascheduler/__init__.py
@@ -1,15 +1,4 @@
-from os import getenv
-
-__version__ = "0.6.0"
-
-CONFIG_FILE = getenv(
-    "YASCHEDULER_CONF_PATH", "/etc/yascheduler/yascheduler.conf"
-)
-LOG_FILE = getenv("YASCHEDULER_LOG_PATH", '/var/log/yascheduler.log')
-PID_FILE = getenv("YASCHEDULER_PID_PATH", '/var/run/yascheduler.pid')
-SLEEP_INTERVAL = 6
-N_IDLE_PASSES = 20
-DEFAULT_NODES_PER_PROVIDER = 10
+from .variables import *
 
 
 def connect_db(config):

--- a/yascheduler/background_worker.py
+++ b/yascheduler/background_worker.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+
+import logging
+import threading
+from datetime import datetime, timedelta
+from typing import Optional
+from yascheduler import SLEEP_INTERVAL
+from yascheduler.utils import sleep_until
+
+
+class BackgroundWorker(threading.Thread):
+    _kill: threading.Event
+    _log: logging.Logger
+    _sleep_interval: float = SLEEP_INTERVAL
+
+    def __init__(
+        self,
+        logger: Optional[logging.Logger] = None,
+        **kwargs,
+    ):
+        super().__init__(target=self.run, **kwargs)
+        if logger:
+            self._log = logger.getChild(self.name)
+        else:
+            self._log = logging.getLogger(self.name)
+        self._kill = threading.Event()
+
+    def stop(self):
+        self._log.info("Stopping thread...")
+        self._kill.set()
+
+    def do_work(self):
+        raise NotImplementedError()
+
+    def run(self):
+        self._log.info("Thread started")
+        while not self._kill.is_set():
+            end_time = datetime.now() + timedelta(seconds=self._sleep_interval)
+            self.do_work()
+            sleep_until(end_time)
+        self._log.info("Thread stopped")

--- a/yascheduler/background_worker.py
+++ b/yascheduler/background_worker.py
@@ -4,8 +4,8 @@ import logging
 import threading
 from datetime import datetime, timedelta
 from typing import Optional
-from yascheduler import SLEEP_INTERVAL
-from yascheduler.utils import sleep_until
+from yascheduler.variables import SLEEP_INTERVAL
+from yascheduler.time import sleep_until
 
 
 class BackgroundWorker(threading.Thread):

--- a/yascheduler/clouds/abstract_cloud_api.py
+++ b/yascheduler/clouds/abstract_cloud_api.py
@@ -31,7 +31,7 @@ class AbstractCloudAPI(object):
     config: ConfigParser
     yascheduler: "Optional['yascheduler.scheduler.Yascheduler']"
 
-    def __init__(self, max_nodes: int = None, logger: logging.Logger = None):
+    def __init__(self, max_nodes: int = None, logger: Optional[logging.Logger] = None):
         if logger:
             self.log = logger.getChild(self.name)
         else:

--- a/yascheduler/clouds/abstract_cloud_api.py
+++ b/yascheduler/clouds/abstract_cloud_api.py
@@ -31,7 +31,11 @@ class AbstractCloudAPI(object):
     config: ConfigParser
     yascheduler: "Optional['yascheduler.scheduler.Yascheduler']"
 
-    def __init__(self, max_nodes: int = None, logger: Optional[logging.Logger] = None):
+    def __init__(
+        self,
+        max_nodes: Optional[int] = None,
+        logger: Optional[logging.Logger] = None,
+    ):
         if logger:
             self.log = logger.getChild(self.name)
         else:

--- a/yascheduler/clouds/cloud_api_manager.py
+++ b/yascheduler/clouds/cloud_api_manager.py
@@ -34,7 +34,7 @@ class CloudAPIManager(object):
     _deallocate_results: "queue.Queue[DeallocateResult]"
     yascheduler: "Optional['yascheduler.scheduler.Yascheduler']"
 
-    def __init__(self, config, logger: logging.Logger = None):
+    def __init__(self, config, logger: Optional[logging.Logger] = None):
         if logger:
             self._log = logger.getChild(self.__class__.__name__)
         else:

--- a/yascheduler/clouds/workers.py
+++ b/yascheduler/clouds/workers.py
@@ -22,7 +22,7 @@ class BackgroundWorker(threading.Thread):
         self,
         config: ConfigParser,
         use_apis: List[str],
-        logger: logging.Logger = None,
+        logger: Optional[logging.Logger] = None,
         **kwargs,
     ):
         super().__init__(target=self.run, **kwargs)

--- a/yascheduler/clouds/workers.py
+++ b/yascheduler/clouds/workers.py
@@ -5,8 +5,8 @@ from configparser import ConfigParser
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 from .abstract_cloud_api import AbstractCloudAPI, load_cloudapi
-from yascheduler import SLEEP_INTERVAL
-from yascheduler.background_worker import BackgroundWorker
+from .. import SLEEP_INTERVAL
+from ..background_worker import BackgroundWorker
 
 
 class CloudWorker(BackgroundWorker):

--- a/yascheduler/scheduler.py
+++ b/yascheduler/scheduler.py
@@ -10,6 +10,7 @@ import logging
 from configparser import ConfigParser
 from datetime import datetime
 from collections import Counter
+from typing import Optional
 
 from fabric import Connection as SSH_Connection
 from yascheduler import connect_db, CONFIG_FILE, SLEEP_INTERVAL, N_IDLE_PASSES
@@ -26,7 +27,7 @@ class Yascheduler(object):
 
     _log: logging.Logger
 
-    def __init__(self, config, logger: logging.Logger = None):
+    def __init__(self, config, logger: Optional[logging.Logger] = None):
         if logger:
             self._log = logger.getChild(self.__class__.__name__)
         else:

--- a/yascheduler/scheduler.py
+++ b/yascheduler/scheduler.py
@@ -8,7 +8,7 @@ import tempfile
 import string
 import logging
 from configparser import ConfigParser
-from datetime import datetime
+from datetime import datetime, timedelta
 from collections import Counter
 from typing import Optional
 
@@ -16,6 +16,7 @@ from fabric import Connection as SSH_Connection
 from yascheduler import connect_db, CONFIG_FILE, SLEEP_INTERVAL, N_IDLE_PASSES
 import yascheduler.clouds
 from yascheduler.engines import init_engines, get_engines_check_cmd
+from yascheduler.utils import sleep_until
 
 logging.basicConfig(level=logging.INFO)
 
@@ -349,8 +350,9 @@ def daemonize(log_file=None):
     # The main scheduler loop
     try:
         while True:
+            end_time = datetime.now() + timedelta(seconds=SLEEP_INTERVAL)
             step()
-            time.sleep(SLEEP_INTERVAL)
+            sleep_until(end_time)
     except KeyboardInterrupt:
         clouds.stop()
 

--- a/yascheduler/scheduler.py
+++ b/yascheduler/scheduler.py
@@ -1,24 +1,26 @@
 #!/usr/bin/env python
 
-import os
-import random
 import json
-import time
-import tempfile
-import string
 import logging
+import os
+import queue
+import random
+import string
+import tempfile
 from configparser import ConfigParser
 from datetime import datetime, timedelta
 from collections import Counter
-from typing import Optional
+from typing import List, Optional
 
 from fabric import Connection as SSH_Connection
 from yascheduler import connect_db, CONFIG_FILE, SLEEP_INTERVAL, N_IDLE_PASSES
 import yascheduler.clouds
 from yascheduler.engines import init_engines, get_engines_check_cmd
-from yascheduler.utils import sleep_until
+from yascheduler.time import sleep_until
+from yascheduler.webhook_worker import WebhookWorker, WebhookTask
 
 logging.basicConfig(level=logging.INFO)
+
 
 class Yascheduler(object):
 
@@ -27,6 +29,8 @@ class Yascheduler(object):
     STATUS_DONE = 2
 
     _log: logging.Logger
+    _webhook_queue: "queue.Queue[WebhookTask]"
+    _webhook_threads: List[WebhookWorker]
 
     def __init__(self, config, logger: Optional[logging.Logger] = None):
         if logger:
@@ -39,6 +43,22 @@ class Yascheduler(object):
         self.ssh_custom_key = {}
         self.clouds = None
         self.engines = init_engines(config)
+        self._webhook_queue = queue.Queue()
+        webhook_thread_num = int(
+            config.get("local", "webhook_threads", fallback=2)
+        )
+        self._webhook_threads = []
+        for i in range(webhook_thread_num):
+            t = WebhookWorker(
+                name=f"WebhookThread[{i}]",
+                logger=self._log,
+                task_queue=self._webhook_queue,
+            )
+            self._webhook_threads.append(t)
+
+    def start(self) -> None:
+        for t in self._webhook_threads:
+            t.start()
 
     def queue_get_resources(self):
         self.cursor.execute('SELECT ip, ncpus, enabled, cloud FROM yascheduler_nodes;')
@@ -82,15 +102,22 @@ class Yascheduler(object):
         self.cursor.execute(sql_statement, params)
         return [dict(task_id=row[0], label=row[1], ip=row[2], status=row[3]) for row in self.cursor.fetchall()]
 
+    def enqueue_task_event(self, task_id: int) -> None:
+        task = self.queue_get_task(task_id) or {}
+        wt = WebhookTask.from_dict(task)
+        self._webhook_queue.put(wt)
+
     def queue_set_task_running(self, task_id, ip):
         self.cursor.execute("UPDATE yascheduler_tasks SET status=%s, ip=%s WHERE task_id=%s;",
                             (self.STATUS_RUNNING, ip, task_id))
         self.connection.commit()
+        self.enqueue_task_event(task_id)
 
     def queue_set_task_done(self, task_id, metadata):
         self.cursor.execute("UPDATE yascheduler_tasks SET status=%s, metadata=%s WHERE task_id=%s;",
                             (self.STATUS_DONE, json.dumps(metadata), task_id))
         self.connection.commit()
+        self.enqueue_task_event(task_id)
         #if self.clouds:
         # TODO: free-up CloudAPIManager().tasks
 
@@ -258,6 +285,12 @@ class Yascheduler(object):
             return self.clouds.get_capacity(resources)
         return 0
 
+    def stop(self):
+        self._log.info("Stopping threads...")
+        for t in self._webhook_threads:
+            t.stop()
+            t.join()
+
 
 def daemonize(log_file=None):
     logger = get_logger(log_file)
@@ -269,6 +302,7 @@ def daemonize(log_file=None):
     ), yascheduler.clouds.CloudAPIManager(config, logger=logger)
     logging.getLogger('Yascheduler').setLevel(logging.DEBUG)
     clouds.initialize()
+    yac.start()
 
     chilling_nodes = Counter() # ips vs. their occurences
 
@@ -292,13 +326,18 @@ def daemonize(log_file=None):
                 except ValueError: pass
             else:
                 ready_task = yac.queue_get_task(task['task_id'])
+                webhook_url = ready_task['metadata'].get('webhook_url')
                 store_folder = ready_task['metadata'].get('local_folder') or \
                     os.path.join(config.get('local', 'data_dir'),
                                  os.path.basename(ready_task['metadata']['remote_folder']))
                 os.makedirs(store_folder, exist_ok=True) # TODO OSError if restart or invalid data_dir
                 yac.ssh_get_task(ready_task['ip'], ready_task['metadata']['engine'], ready_task['metadata']['remote_folder'], store_folder)
-                ready_task['metadata'] = dict(remote_folder=ready_task['metadata']['remote_folder'],
-                                              local_folder=store_folder)
+                ready_task['metadata'] = dict(
+                    remote_folder=ready_task['metadata']['remote_folder'],
+                    local_folder=store_folder,
+                )
+                if webhook_url:
+                    ready_task['metadata']['webhook_url'] = webhook_url
                 yac.queue_set_task_done(ready_task['task_id'], ready_task['metadata'])
                 logger.info(':::task_id={} {} done and saved in {}'.format(task['task_id'], ready_task['label'],
                                                                 ready_task['metadata'].get('local_folder')))
@@ -355,6 +394,7 @@ def daemonize(log_file=None):
             sleep_until(end_time)
     except KeyboardInterrupt:
         clouds.stop()
+        yac.stop()
 
 
 def get_logger(log_file):

--- a/yascheduler/time.py
+++ b/yascheduler/time.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+from datetime import datetime
+from time import sleep
+
+
+def sleep_until(end: datetime) -> None:
+    "Sleep until :end:"
+    now = datetime.now()
+    if now >= end:
+        return
+    sleep((end - now).total_seconds())

--- a/yascheduler/utils.py
+++ b/yascheduler/utils.py
@@ -4,24 +4,15 @@ Console scripts for yascheduler
 import os
 import argparse
 from configparser import ConfigParser
-from datetime import datetime
-from time import sleep
 
 from pg8000 import ProgrammingError
 from fabric import Connection as SSH_Connection
 from paramiko.rsakey import RSAKey
 from invoke.exceptions import UnexpectedExit
 
-from yascheduler import CONFIG_FILE, has_node, add_node, remove_node
+from yascheduler import has_node, add_node, remove_node
+from yascheduler.variables import CONFIG_FILE
 from yascheduler.scheduler import Yascheduler
-
-
-def sleep_until(end: datetime) -> None:
-    "Sleep until :end:"
-    now = datetime.now()
-    if now >= end:
-        return
-    sleep((now - end).total_seconds())
 
 
 def submit():

--- a/yascheduler/utils.py
+++ b/yascheduler/utils.py
@@ -4,6 +4,8 @@ Console scripts for yascheduler
 import os
 import argparse
 from configparser import ConfigParser
+from datetime import datetime
+from time import sleep
 
 from pg8000 import ProgrammingError
 from fabric import Connection as SSH_Connection
@@ -12,6 +14,14 @@ from invoke.exceptions import UnexpectedExit
 
 from yascheduler import CONFIG_FILE, has_node, add_node, remove_node
 from yascheduler.scheduler import Yascheduler
+
+
+def sleep_until(end: datetime) -> None:
+    "Sleep until :end:"
+    now = datetime.now()
+    if now >= end:
+        return
+    sleep((now - end).total_seconds())
 
 
 def submit():

--- a/yascheduler/variables.py
+++ b/yascheduler/variables.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+from os import getenv
+
+__version__ = "0.6.0"
+
+CONFIG_FILE = getenv(
+    "YASCHEDULER_CONF_PATH", "/etc/yascheduler/yascheduler.conf"
+)
+LOG_FILE = getenv("YASCHEDULER_LOG_PATH", "/var/log/yascheduler.log")
+PID_FILE = getenv("YASCHEDULER_PID_PATH", "/var/run/yascheduler.pid")
+SLEEP_INTERVAL = 6
+N_IDLE_PASSES = 20
+DEFAULT_NODES_PER_PROVIDER = 10

--- a/yascheduler/webhook_worker.py
+++ b/yascheduler/webhook_worker.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+
+import inspect
+import queue
+import dataclasses
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util import Retry
+from yascheduler.background_worker import BackgroundWorker
+
+
+def from_dict_to_dataclass(cls, data: Dict[str, Any]):
+    new_dict = {
+        key: (
+            data.get(key)
+            if val.default == val.empty
+            else data.get(key, val.default)
+        )
+        for key, val in inspect.signature(cls).parameters.items()
+    }
+    return cls(**new_dict)
+
+
+@dataclass
+class WebhookTaskMetadata:
+    webhook_url: Optional[str]
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "WebhookTaskMetadata":
+        return from_dict_to_dataclass(cls, data)
+
+
+@dataclass
+class WebhookTask:
+    status: int
+    metadata: WebhookTaskMetadata
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "WebhookTask":
+        return from_dict_to_dataclass(cls, data)
+
+    def __post_init__(self) -> None:
+        if isinstance(self.metadata, dict):
+            self.metadata = WebhookTaskMetadata.from_dict(self.metadata)
+
+
+@dataclass
+class WebhookPayload:
+    status: int
+
+
+class WebhookWorker(BackgroundWorker):
+    _task_queue: "queue.Queue[WebhookTask]"
+    http: requests.Session
+
+    def __init__(
+        self,
+        task_queue: "queue.Queue[WebhookTask]",
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self._task_queue = task_queue
+        retry_strategy = Retry(total=5, backoff_factor=1)
+        adapter = HTTPAdapter(max_retries=retry_strategy)
+        self.http = requests.Session()
+        self.http.mount("https://", adapter)
+        self.http.mount("http://", adapter)
+
+    def do_work(self) -> None:
+        try:
+            t = self._task_queue.get(False)
+        except queue.Empty:
+            return
+
+        if not isinstance(t.metadata.webhook_url, str):
+            self._task_queue.task_done()
+            return
+
+        self._log.info(f"Executing webhook to {t.metadata.webhook_url}")
+        payload = WebhookPayload(status=t.status)
+        try:
+            response = self.http.post(
+                url=t.metadata.webhook_url,
+                json=dataclasses.asdict(payload),
+            )
+            response.raise_for_status()
+        except requests.exceptions.RequestException as e:
+            self._log.info(
+                f"Webhook to {t.metadata.webhook_url} failed: {str(e)}"
+            )
+
+        self._task_queue.task_done()


### PR DESCRIPTION
New dependency - `requests`. Actually, already present because of `azure` libraries.

Implemented threaded webhooks support:
`Yascheduler` starts background `WebhookWorker` threads. Every time the task status is updated On every task status updated (become running or done), it sends task status and metadata to the `WebhookWorker` threads.
If task have a `webhook_url` property in metadata, `WebhookWorker` make a `POST` request to the url `webhook_url` with payload `{ status: int }`.


Less notable changes:
- Generalized `BackgroundWorker` for all workers: `WebhookWorker`, `AllocationWorker`, `DeallocationWorker`.
- Typing fixes.
- Sleep until `current loop step start time + SLEEP_INTERVAL` instead of `current loop step end time + SLEEP_INTERVAL` for main daemon loop and all threads loops.
- Move some variables to the `variables.py` from `__init__.py` because of circular dependencies error.