### PR TITLE
fix: sql query typo

### DIFF
--- a/yascheduler/scheduler.py
+++ b/yascheduler/scheduler.py
@@ -68,7 +68,7 @@ class Yascheduler(object):
         self.cursor.execute(
             (
                 "SELECT ip, ncpus, enabled, cloud "
-                "FROM yascheduler_nodes WHERE ip=(%S);"
+                "FROM yascheduler_nodes WHERE ip=%s;"
             ),
             (ip),
         )


### PR DESCRIPTION
Fix this:
```sh
❯ yasetnode 127.0.0.1~4
ERROR:Yascheduler:Host root@127.0.0.1 is unreachable due to: Only %s and %% are supported in the query.
Failed to add host to yascheduler: 127.0.0.1
```