### PR TITLE
fix: sql typos again

### DIFF
--- a/yascheduler/scheduler.py
+++ b/yascheduler/scheduler.py
@@ -70,7 +70,7 @@ class Yascheduler(object):
                 "SELECT ip, ncpus, enabled, cloud "
                 "FROM yascheduler_nodes WHERE ip=%s;"
             ),
-            (ip),
+            [ip],
         )
         return self.cursor.fetchone()
 


### PR DESCRIPTION
Fix this type of error:
```sh
ERROR:Yascheduler:Host root@127.0.0.1 is unreachable due to: {'S': 'ERROR', 'V': 'ERROR', 'C': '08P01', 'M': 'bind message supplies 9 parameters, but prepared statement "" requires 1', 'F': 'postgres.c', 'L': '1672', 'R': 'exec_bind_message'}
Failed to add host to yascheduler: 127.0.0.1
```
:suspect: 