### PR TITLE
Plumbum DSL for shell operations

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pg8000
 paramiko~=2.10.1
-fabric
+plumbum>=1.7.0
 python-daemon
 requests>=2.21
 

--- a/yascheduler/clouds/cloud_api_manager.py
+++ b/yascheduler/clouds/cloud_api_manager.py
@@ -112,7 +112,6 @@ class CloudAPIManager(object):
         assert self.yascheduler
         for cloudapi in self.apis:
             self.apis[cloudapi].yascheduler = self.yascheduler
-            self.apis[cloudapi].init_key()
 
         for t in self._allocators:
             t.start()

--- a/yascheduler/clouds/workers.py
+++ b/yascheduler/clouds/workers.py
@@ -76,7 +76,6 @@ class AllocatorWorker(CloudWorker):
             return
 
         try:
-            api.init_key()
             self._log.info("Creating a node...")
             r.ip = api.create_node()
             self._log.info(f"Created: {r.ip}")
@@ -133,7 +132,6 @@ class DeallocatorWorker(CloudWorker):
             return
 
         try:
-            api.init_key()
             self._log.info(f"Deleting the {r.ip} node...")
             api.delete_node(r.ip)
             self._log.info(f"Node {r.ip} is deleted")

--- a/yascheduler/data/yascheduler.conf
+++ b/yascheduler/data/yascheduler.conf
@@ -22,9 +22,8 @@ user = root
 [engine.pcrystal]
 platform_packages = openmpi-bin wget
 deploy_local_files = Pcrystal
-spawn = nohup sh -c "cp {task_path}/INPUT {task_path}/OUTPUT && mpirun -np {ncpus} --allow-run-as-root -wd {task_path} $(realpath {engine_path}/Pcrystal) >> {task_path}/OUTPUT 2>&1" &
-check = ps aux | grep crystal
-run_marker = Pcrystal
+spawn = cp {task_path}/INPUT OUTPUT && mpirun -np {ncpus} --allow-run-as-root -wd {task_path} {engine_path}/Pcrystal >> OUTPUT 2>&1
+check_pname = Pcrystal
 sleep_interval = 6
 input_files =
     INPUT
@@ -38,17 +37,16 @@ output_files =
 
 [engine.dummy]
 deploy_local_files = dummyengine
-spawn = nohup sh -c "{engine_path}/dummyengine {task_path}/*" &
-check = ps aux | grep ummyengine
-run_marker = dummyengine
+spawn = {engine_path}/dummyengine *
+check_pname = dummyengine
 sleep_interval = 1
 input_files = 1.input 2.input 3.input
 output_files = 1.input 2.input 3.input 1.input.out 2.input.out 3.input.out
 
 [engine.gulp]
 deploy_local_files = gulp
-spawn = nohup sh -c "{engine_path}/gulp < {task_path}/INPUT > {task_path}/OUTPUT" &
-check = ps aux | grep ulp
+spawn = {engine_path}/gulp < INPUT > OUTPUT
+check_pname = gulp
 run_marker = gulp
 sleep_interval = 1
 input_files = INPUT

--- a/yascheduler/ssh.py
+++ b/yascheduler/ssh.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+from functools import partial
+from pathlib import Path
+from typing import Optional
+
+from paramiko.client import AutoAddPolicy
+from paramiko.ssh_exception import AuthenticationException
+from plumbum.machines.paramiko_machine import ParamikoMachine
+
+
+class MyParamikoMachine(ParamikoMachine):
+    @classmethod
+    def create_machine(
+        cls,
+        host: str,
+        user: str,
+        keys_dir: Optional[Path] = None,
+        missing_host_policy=AutoAddPolicy,
+        **kwargs,
+    ) -> "MyParamikoMachine":
+        keys_paths = []
+        if keys_dir:
+            keys_paths = list(filter(lambda x: x.is_file(), keys_dir.iterdir()))
+
+        connect = partial(
+            cls,
+            host=host,
+            user=user,
+            missing_host_policy=missing_host_policy,
+            **kwargs,
+        )
+
+        for keyfile in keys_paths:
+            try:
+                return connect(keyfile=str(keyfile))
+            except AuthenticationException:
+                pass
+
+        return connect()


### PR DESCRIPTION
Introducing the use of Plumbum DSL for shell operations instead of the raw `fabric` commands. `paramiko` is used under the hood as before.

Rudimentary multi-key support: Try to connect using every single key in `keys_dir` instead of just one.

Always run engine's spawn command in background `nohup`ped subschell, so construction `nohup sh -c " ... " &` is not required. Also, run engine's spawn in task's data directory.

Abandon `check` and `run_marker` configuration options (`[engine.*]` sections).
Introduce `check_pname` optional option - process name of running engine.
Introduce `check_cmd` and `check_cmd_code` optional options - shell command that returns `check_cmd` code when engine is running.
At least `check_pname` or `check_cmd` must be set.

Try to always use `Path` (`pathlib`) or `RemotePath` (`plumbum`) instead of plain strings.