### PR TITLE
Allow to set logging level as command line argument

### DIFF
--- a/yascheduler/scheduler.py
+++ b/yascheduler/scheduler.py
@@ -43,12 +43,12 @@ from .variables import CONFIG_FILE
 logging.basicConfig(level=logging.INFO)
 
 
-def get_logger(log_file):
+def get_logger(log_file, level: int = logging.INFO):
     logger = logging.getLogger("yascheduler")
-    logger.setLevel(logging.INFO)
+    logger.setLevel(level)
 
     backoff_logger = logging.getLogger("backoff")
-    backoff_logger.setLevel(logging.ERROR)
+    backoff_logger.setLevel(logging.ERROR if level >= logging.INFO else logging.DEBUG)
 
     if log_file:
         fh = logging.FileHandler(log_file)

--- a/yascheduler/utils.py
+++ b/yascheduler/utils.py
@@ -431,7 +431,17 @@ def manage_node():
 
 
 def daemonize(log_file=None):
-    logger = get_logger(log_file)
+    parser = argparse.ArgumentParser(description="Start yascheduler daemon")
+    parser.add_argument(
+        "-l",
+        "--log-level",
+        default="INFO",
+        help="set log level",
+        choices=logging._levelToName.values(),
+    )
+    args = parser.parse_args()
+
+    logger = get_logger(log_file, level=logging._nameToLevel[args.log_level])
 
     async def on_signal(
         y: Scheduler, shield: Sequence[asyncio.Task], signame: str, signum: int


### PR DESCRIPTION
```
usage: yascheduler [-h] [-l {CRITICAL,ERROR,WARNING,INFO,DEBUG,NOTSET}]

Start yascheduler daemon

options:
  -h, --help            show this help message and exit
  -l {CRITICAL,ERROR,WARNING,INFO,DEBUG,NOTSET}, --log-level {CRITICAL,ERROR,WARNING,INFO,DEBUG,NOTSET}
                        set log level
```