### PR TITLE
fix: greedy allocation

### DIFF
--- a/yascheduler/clouds/cloud_api_manager.py
+++ b/yascheduler/clouds/cloud_api_manager.py
@@ -159,7 +159,6 @@ class CloudAPIManager(PCloudAPIManager):
             return await self.allocate_node(want_platforms, throttle)
         except Exception as err:
             self.log.error(f"Can't allocate node: {err}")
-        finally:
             if on_task:
                 self.mark_task_done(on_task)
         return

--- a/yascheduler/scheduler.py
+++ b/yascheduler/scheduler.py
@@ -326,6 +326,7 @@ class Scheduler:
                 await self.do_task_webhook(
                     task.task_id, task_m.metadata, TaskStatus.RUNNING
                 )
+                self.clouds.mark_task_done(task.task_id)
                 return True
 
         # free machine not found - try to allocate new node


### PR DESCRIPTION
Fix case when allocate more nodes than tasks. Like 5 nodes for 3 tasks.
Details:
Mark task is done (in cloud api manager meaning) not when node is allocated by when task is really allocated to any node.