### PR TITLE
Remote `engine.platforms` default value

### DIFF
--- a/yascheduler/config/engine.py
+++ b/yascheduler/config/engine.py
@@ -147,6 +147,6 @@ class Engine:
             input_files=gettuple("input_files"),
             output_files=gettuple("output_files"),
             sleep_interval=sec.getint("sleep_interval"),
-            platforms=gettuple("platforms") or ["debian-10"],
+            platforms=gettuple("platforms"),
             platform_packages=gettuple("platform_packages"),
         )


### PR DESCRIPTION
Run on any node if no platforms.