### PR TITLE
fix: cloud init pkgs when engine without platform

### DIFF
--- a/yascheduler/clouds/cloud_api.py
+++ b/yascheduler/clouds/cloud_api.py
@@ -118,7 +118,9 @@ class CloudAPI(PCloudAPI[TConfigCloud_contra]):
     async def get_cloud_config_data(self) -> PCloudConfig:
         "Common cloud-config"
         engines = self.engines.filter(
-            lambda e: any(map(self.is_platform_supported, e.platforms))
+            lambda e: bool(e.platforms)
+            and any(map(self.is_platform_supported, e.platforms))
+            or not e.platforms
         )
         pkgs = engines.get_platform_packages()
         return CloudConfig(package_upgrade=True, packages=pkgs)


### PR DESCRIPTION
Engines without platforms are skipped in cloud init config. That shouldn't affect node setup because packages are installed later. 