### PR TITLE
Fail loud when node setup is failed

### DIFF
--- a/yascheduler/remote_machine/windows_methods.py
+++ b/yascheduler/remote_machine/windows_methods.py
@@ -138,7 +138,8 @@ async def deploy_local_archive(
     await run(
         f"""Expand-Archive {quote(str(rpath))} `
             -DestinationPath {quote(str(engine_dir))} `
-            -Force"""
+            -Force""",
+        check=True,
     )
     await sftp.remove(rpath)
 
@@ -161,14 +162,16 @@ async def deploy_remote_archive(
         log.debug(f"Downloading {url} to {str(rpath)}...")
     await run(
         f"""Invoke-WebRequest -Uri {quote(url)} `
-            -OutFile {quote(str(rpath))} -Force"""
+            -OutFile {quote(str(rpath))} -Force""",
+        check=True,
     )
     if log:
         log.debug(f"Unarchiving {name}...")
     await run(
         f"""Expand-Archive {quote(str(rpath))} `
             -DestinationPath {quote(str(engine_dir))} `
-            -Force"""
+            -Force""",
+        check=True,
     )
     await sftp.remove(rpath)
 


### PR DESCRIPTION
Example:
```
ERROR:yascheduler.Scheduler.CloudAPIManager.hetzner:Setup node 135.181.207.148 failed: command 'apt-get -o DPkg::Lock::Timeout=600 -y openmpi-bin wget' failed with exit code 100; stderr: E: Invalid operation openmpi-bin

WARNING:yascheduler.Scheduler.CloudAPIManager.hetzner:Setup node 135.181.207.148 failed - deallocate
INFO:yascheduler.Scheduler.CloudAPIManager.hetzner:DELETED 135.181.207.148
ERROR:yascheduler.Scheduler.CloudAPIManager:Can't allocate node: Setup node error: Process exited with non-zero exit status 100
```