### PR TITLE
Task result download

### DIFF
--- a/yascheduler/remote_machine/protocol.py
+++ b/yascheduler/remote_machine/protocol.py
@@ -35,23 +35,33 @@ from asyncssh.misc import (
 from asyncssh.process import SSHClientProcess, SSHCompletedProcess
 from asyncssh.sftp import (
     SFTPBadMessage,
+    SFTPByteRangeLockConflict,
+    SFTPByteRangeLockRefused,
     SFTPClient,
     SFTPConnectionLost,
-    SFTPError,
+    SFTPDeletePending,
+    SFTPEOFError,
     SFTPFailure,
     SFTPInvalidHandle,
+    SFTPLockConflict,
     SFTPNoConnection,
+    SFTPNoMatchingByteRangeLock,
 )
 from typing_extensions import Protocol, Self, TypedDict, Unpack
 
 SFTPRetryExc = (
     asyncio.exceptions.TimeoutError,
-    SFTPError,
+    SFTPEOFError,
     SFTPFailure,
     SFTPBadMessage,
     SFTPNoConnection,
     SFTPConnectionLost,
     SFTPInvalidHandle,
+    SFTPLockConflict,
+    SFTPByteRangeLockConflict,
+    SFTPByteRangeLockRefused,
+    SFTPDeletePending,
+    SFTPNoMatchingByteRangeLock,
 )
 SSHRetryExc = (
     OSError,


### PR DESCRIPTION
On task results download retry only on non-fatal errors. Don't fail on all downloads on error. Collect all errors from all downloads.