### PR TITLE
fix: python3.7 incompatibility

### DIFF
--- a/yascheduler/remote_machine/protocol.py
+++ b/yascheduler/remote_machine/protocol.py
@@ -50,7 +50,7 @@ from asyncssh.sftp import (
 from typing_extensions import Protocol, Self, TypedDict, Unpack
 
 SFTPRetryExc = (
-    asyncio.exceptions.TimeoutError,
+    asyncio.TimeoutError,
     SFTPEOFError,
     SFTPFailure,
     SFTPBadMessage,
@@ -65,7 +65,7 @@ SFTPRetryExc = (
 )
 SSHRetryExc = (
     OSError,
-    asyncio.exceptions.TimeoutError,
+    asyncio.TimeoutError,
     CompressionError,
     ConnectionLost,
     KeyExchangeFailed,


### PR DESCRIPTION
There is no `asyncio.exceptions` module in python3.7. So, `setup.py` is silently fail on `pip install ....`

Close #86
