### PR TITLE
fix: remote config omitted on cloud node allocation

### DIFF
--- a/yascheduler/clouds/cloud_api.py
+++ b/yascheduler/clouds/cloud_api.py
@@ -11,7 +11,7 @@ from asyncssh.process import ProcessError
 from asyncssh.public_key import SSHKey, generate_private_key, read_private_key
 from attrs import asdict, define, field
 
-from ..config import ConfigLocal, EngineRepository
+from ..config import ConfigLocal, ConfigRemote, EngineRepository
 from ..remote_machine import PRemoteMachine, RemoteMachine, SSHRetryExc
 from .protocols import PCloudAdapter, PCloudAPI, PCloudConfig, TConfigCloud_contra
 from .utils import get_rnd_name
@@ -47,6 +47,7 @@ class CloudAPI(PCloudAPI[TConfigCloud_contra]):
     adapter: PCloudAdapter[TConfigCloud_contra] = field()
     config: TConfigCloud_contra = field()
     local_config: ConfigLocal = field()
+    remote_config: ConfigRemote = field()
     engines: EngineRepository = field()
     log: logging.Logger = field()
     ssh_key_lock: asyncio.Lock = field(factory=asyncio.Lock)
@@ -62,6 +63,7 @@ class CloudAPI(PCloudAPI[TConfigCloud_contra]):
         adapter: PCloudAdapter,
         config: TConfigCloud_contra,
         local_config: ConfigLocal,
+        remote_config: ConfigRemote,
         engines: EngineRepository,
         log: Optional[logging.Logger] = None,
         ssh_key_lock: Optional[asyncio.Lock] = None,
@@ -76,6 +78,7 @@ class CloudAPI(PCloudAPI[TConfigCloud_contra]):
             adapter=adapter,
             config=config,
             local_config=local_config,
+            remote_config=remote_config,
             engines=engines,
             log=log,
             ssh_key_lock=ssh_key_lock or asyncio.Lock(),
@@ -143,6 +146,9 @@ class CloudAPI(PCloudAPI[TConfigCloud_contra]):
             client_keys=keys,
             logger=self.log,
             connect_timeout=self.adapter.create_node_conn_timeout,
+            data_dir=self.remote_config.data_dir,
+            engines_dir=self.remote_config.engines_dir,
+            tasks_dir=self.remote_config.tasks_dir,
             jump_host=self.config.jump_host,
             jump_username=self.config.jump_username,
         )

--- a/yascheduler/clouds/cloud_api_manager.py
+++ b/yascheduler/clouds/cloud_api_manager.py
@@ -9,7 +9,7 @@ from typing import Mapping, Optional, Sequence, Set, Union
 from attrs import define, field
 from typing_extensions import Self
 
-from ..config import ConfigCloud, ConfigLocal, EngineRepository
+from ..config import ConfigCloud, ConfigLocal, ConfigRemote, EngineRepository
 from ..db import DB
 from .adapters import azure_adapter, hetzner_adapter, upcloud_adapter
 from .cloud_api import CloudAPI
@@ -32,6 +32,7 @@ class CloudAPIManager(PCloudAPIManager):
         cls,
         db: DB,
         local_config: ConfigLocal,
+        remote_config: ConfigRemote,
         cloud_configs: Sequence[ConfigCloud],
         engines: EngineRepository,
         log: Optional[logging.Logger] = None,
@@ -62,6 +63,7 @@ class CloudAPIManager(PCloudAPIManager):
                     adapter=adapter,
                     config=cfg,
                     local_config=local_config,
+                    remote_config=remote_config,
                     engines=engines,
                     ssh_key_lock=ssh_key_lock,
                     log=log,

--- a/yascheduler/clouds/protocols.py
+++ b/yascheduler/clouds/protocols.py
@@ -10,7 +10,7 @@ from asyncssh.public_key import SSHKey
 from attr import define
 from typing_extensions import Protocol, Self
 
-from ..config import ConfigCloud, ConfigLocal, EngineRepository
+from ..config import ConfigCloud, ConfigLocal, ConfigRemote, EngineRepository
 from ..db import DB
 
 SupportedPlatformChecker = Callable[[str], bool]
@@ -103,6 +103,7 @@ class PCloudAPI(Protocol[TConfigCloud_contra]):
     name: str
     config: TConfigCloud_contra
     local_config: ConfigLocal
+    remote_config: ConfigRemote
     engines: EngineRepository
     log: logging.Logger
 
@@ -113,6 +114,7 @@ class PCloudAPI(Protocol[TConfigCloud_contra]):
         adapter: PCloudAdapter[TConfigCloud_contra],
         config: TConfigCloud_contra,
         local_config: ConfigLocal,
+        remote_config: ConfigRemote,
         engines: EngineRepository,
         ssh_key_lock: Optional[asyncio.Lock] = None,
         log: Optional[logging.Logger] = None,
@@ -171,6 +173,7 @@ class PCloudAPIManager(Protocol):
         cls,
         db: DB,
         local_config: ConfigLocal,
+        remote_config: ConfigRemote,
         cloud_configs: Sequence[ConfigCloud],
         engines: EngineRepository,
         log: Optional[logging.Logger] = None,

--- a/yascheduler/scheduler.py
+++ b/yascheduler/scheduler.py
@@ -115,6 +115,7 @@ class Scheduler:
         clouds = await CloudAPIManager.create(
             db=db,
             local_config=cfg.local,
+            remote_config=cfg.remote,
             cloud_configs=cfg.clouds,
             engines=cfg.engines,
             log=log,


### PR DESCRIPTION
Fix `RemoteMachine`'s `engines_dir` is not set when cloud node is allocated.