### PR TITLE
Fix machine occupancy

### DIFF
--- a/yascheduler/remote_machine/protocol.py
+++ b/yascheduler/remote_machine/protocol.py
@@ -204,7 +204,7 @@ class PRemoteMachineAdapter(Protocol):
 
 
 class PRemoteMachineMetadata(Protocol):
-    busy: bool
+    busy: Optional[bool]
 
     @abstractmethod
     def is_free_longer_than(self, delta: timedelta) -> bool:

--- a/yascheduler/remote_machine/remote_machine.py
+++ b/yascheduler/remote_machine/remote_machine.py
@@ -89,11 +89,11 @@ DEFAULT_CONN_OPTS = SSHClientConnectionOptions(
 @define
 class RemoteMachineMetadata(PRemoteMachineMetadata):
     def __init__(self):
-        self._busy = False
+        self._busy = None
         self._free_since: Optional[datetime] = datetime.now()
 
     @property
-    def busy(self) -> bool:
+    def busy(self) -> Optional[bool]:
         return self._busy
 
     @busy.setter

--- a/yascheduler/remote_machine/remote_machine.py
+++ b/yascheduler/remote_machine/remote_machine.py
@@ -372,9 +372,6 @@ class RemoteMachine(PRemoteMachine):
         """
         Check node occupancy by task for target engine
         """
-        # if engine is not supported on the machine
-        if not (set(engine.platforms) & set(self.platforms)):
-            return False
         if engine.check_pname:
             try:
                 if [x async for x in self.pgrep(engine.check_pname)]:

--- a/yascheduler/scheduler.py
+++ b/yascheduler/scheduler.py
@@ -524,6 +524,11 @@ class Scheduler:
                 )
                 await self.do_task_webhook(task_id, task.metadata, TaskStatus.DONE)
             return
+        # if machine state is unknown
+        if machine.meta.busy is None:
+            engine = self.config.engines.get(task.metadata["engine"])
+            if engine:
+                await machine.start_occupancy_check(engine)
         # consume
         if not machine.meta.busy:
             self.log.debug(f"machine {machine.hostname} is free for task {task_id}")


### PR DESCRIPTION
Remove useless check that prevent run machine occupancy checks and leads to premature end of task.

Change machine's "busy" state to ternary: busy, free, unknown. If state is unknown and task is assigned to the machine, then run occupancy check before results download. This allows to survive daemon restarts.