### PR TITLE
fix: workaround python bug in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,9 @@ class CustomInstall(install):
     """Custom install"""
 
     def run(self):
+        # workaround https://github.com/python/cpython/issues/86813
+        from concurrent.futures import ThreadPoolExecutor  # noqa: F401
+
         def _post_install():
             from yascheduler.variables import CONFIG_FILE
 


### PR DESCRIPTION
There is python bug https://github.com/python/cpython/issues/86813 that leads `setup.py` to fail on some 3.9 and 3.10 versions:
```
Exception ignored in atexit callback: <function CustomInstall.run.<locals>._post_install at 0x7fc2343544c0>
Traceback (most recent call last):
  File "/code/setup.py", line 26, in _post_install
    from yascheduler.variables import CONFIG_FILE
  File "/code/yascheduler/__init__.py", line 2, in <module>
    from .client import Yascheduler
  File "/code/yascheduler/client.py", line 11, in <module>
    from .db import DB, TaskModel, TaskStatus
  File "/code/yascheduler/db.py", line 6, in <module>
    from concurrent.futures import ThreadPoolExecutor
  File "<frozen importlib._bootstrap>", line 1075, in _handle_fromlist
  File "/usr/local/lib/python3.10/concurrent/futures/__init__.py", line 49, in __getattr__
    from .thread import ThreadPoolExecutor as te
  File "/usr/local/lib/python3.10/concurrent/futures/thread.py", line 37, in <module>
    threading._register_atexit(_python_exit)
  File "/usr/local/lib/python3.10/threading.py", line 1504, in _register_atexit
    raise RuntimeError("can't register atexit after shutdown")
RuntimeError: can't register atexit after shutdown
```

Simple workaround added.