### PR TITLE
Change default hetzner OS to debian-11

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Settings prefix is `hetzner`.
 
   Image name for new nodes.
 
-  _Default_: `debian-10`
+  _Default_: `debian-11`
 
 #### Azure
 

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ Settings prefix is `hetzner`.
 
   Server type (size).
 
-  _Default_: `cx51`
+  _Default_: `cx52`
 
 - `hetzner_image_name`
 

--- a/yascheduler/config/cloud.py
+++ b/yascheduler/config/cloud.py
@@ -127,7 +127,7 @@ class ConfigCloudHetzner:
     max_nodes: int = _make_default_field(10, extra_validators=[validators.ge(0)])
     username: str = _make_default_field("root")
     priority: int = _make_default_field(0)
-    server_type: str = _make_default_field("cx51")
+    server_type: str = _make_default_field("cx52")
     image_name: str = _make_default_field("debian-11")
     idle_tolerance: int = _make_default_field(120, extra_validators=[validators.ge(1)])
     jump_username: Optional[str] = field(default=None, validator=opt_str_val)

--- a/yascheduler/config/cloud.py
+++ b/yascheduler/config/cloud.py
@@ -128,7 +128,7 @@ class ConfigCloudHetzner:
     username: str = _make_default_field("root")
     priority: int = _make_default_field(0)
     server_type: str = _make_default_field("cx51")
-    image_name: str = _make_default_field("debian-10")
+    image_name: str = _make_default_field("debian-11")
     idle_tolerance: int = _make_default_field(120, extra_validators=[validators.ge(1)])
     jump_username: Optional[str] = field(default=None, validator=opt_str_val)
     jump_host: Optional[str] = field(default=None, validator=opt_str_val)


### PR DESCRIPTION
Fix for yascheduler error: "ERROR:yascheduler.Scheduler.CloudAPIManager:Can't allocate node: Create node error: image 'debian-10' not found" 

debian-11 work just fine