### PR TITLE
Fix shell stuff

### DIFF
--- a/examples/submit_any_engine_input.py
+++ b/examples/submit_any_engine_input.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
 
-import os
 import argparse
+import os
 
 from yascheduler import Yascheduler
-
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-f", dest="file", action="store", type=str, required=True)

--- a/yascheduler/config/utils.py
+++ b/yascheduler/config/utils.py
@@ -28,4 +28,5 @@ def warn_unknown_fields(known_fields: Sequence[str], sec: SectionProxy) -> None:
         warnings.warn(
             f"Config section {sec.name} unknown fields: {', '.join(unknown_fields)}",
             ConfigWarning,
+            3,
         )

--- a/yascheduler/db.py
+++ b/yascheduler/db.py
@@ -243,7 +243,9 @@ class DB:
     ) -> Sequence[int]:
         """Get task ids by ip and status"""
         rows = await self.run(
-            "SELECT task_id FROM yascheduler_tasks WHERE ip=:ip AND status=:status ORDER BY task_id;",
+            """SELECT task_id FROM yascheduler_tasks
+            WHERE ip=:ip AND status=:status
+            ORDER BY task_id;""",
             ip=ip_addr,
             status=status.value,
         )

--- a/yascheduler/remote_machine/checks.py
+++ b/yascheduler/remote_machine/checks.py
@@ -21,7 +21,9 @@ async def check_is_linux(conn: SSHClientConnection) -> bool:
 @lru_cache
 async def _get_os_release(conn: SSHClientConnection) -> Optional[Tuple[str, str, str]]:
     "Get os release string on linuxes"
-    proc = await conn.run("source /etc/os-release; echo $ID@@@$ID_LIKE@@@$VERSION_ID")
+    proc = await conn.run(
+        "sh -c 'source /etc/os-release; echo $ID@@@$ID_LIKE@@@$VERSION_ID'"
+    )
     if proc.returncode != 0 or not proc.stdout:
         return None
     return tuple(map(lambda x: x.strip(), str(proc.stdout).split("@@@", maxsplit=3)))

--- a/yascheduler/remote_machine/checks.py
+++ b/yascheduler/remote_machine/checks.py
@@ -19,7 +19,7 @@ async def check_is_linux(conn: SSHClientConnection) -> bool:
 
 
 @lru_cache
-async def _get_os_release(conn: SSHClientConnection) -> Optional[Tuple[str, str, str]]:
+async def _get_os_release(conn: SSHClientConnection) -> Optional[Tuple[str]]:
     "Get os release string on linuxes"
     proc = await conn.run(
         "sh -c 'source /etc/os-release; echo $ID@@@$ID_LIKE@@@$VERSION_ID'"
@@ -32,7 +32,7 @@ async def _get_os_release(conn: SSHClientConnection) -> Optional[Tuple[str, str,
 async def check_is_debian_like(conn: SSHClientConnection) -> bool:
     "Check for any Debian-like"
     os_release = await _get_os_release(conn)
-    return "debian" in [os_release[0], os_release[1]] if os_release else False
+    return "debian" in os_release[0:2] if os_release else False
 
 
 async def check_is_debian(conn: SSHClientConnection) -> bool:
@@ -44,7 +44,7 @@ async def check_is_debian(conn: SSHClientConnection) -> bool:
 async def _check_debian_version(version: str, conn: SSHClientConnection) -> bool:
     "Check for Debian version"
     os_release = await _get_os_release(conn)
-    return os_release[2] == version if os_release else False
+    return len(os_release) >= 2 and os_release[2] == version if os_release else False
 
 
 check_is_debian_10 = partial(_check_debian_version, "10")

--- a/yascheduler/utils.py
+++ b/yascheduler/utils.py
@@ -1,6 +1,7 @@
 """
 Console scripts for yascheduler
 """
+
 import argparse
 import asyncio
 import logging


### PR DESCRIPTION
Fix two small bugs in OS detection code:

Unable to get an OS release if the login shell is not POSIX-compliant (`fish`, for example).

Inaccurate handling of tuples leads to an exception and endless spamming of the faulty node (but now I know that `asyncssh` can easily handle 10000 idle connections).