### PR TITLE
Trying to fix pypi publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,13 @@ on:
   workflow_dispatch:
 
 jobs:
-  pypi:
+  pypi-publish:
     runs-on: ubuntu-latest
+    # Specifying a GitHub environment is optional, but strongly encouraged
+    environment: pypi
+    permissions:
+      # IMPORTANT: this permission is mandatory for Trusted Publishing
+      id-token: write
     concurrency:
       group: release
 
@@ -38,5 +43,3 @@ jobs:
 
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Current publishing procedure is broken because of "User 'tilde' does not have two-factor authentication enabled." Therefore, it should be enabled.

In addition, the current approach is to configure Trusted Publisher on the PyPi side:

> Warning: A new Trusted Publisher for the currently running publishing workflow can be created by accessing the following link(s) while logged-in as an owner of the package(s):
> - https://pypi.org/manage/project/yascheduler/settings/publishing/?provider=github&owner=tilde-lab&repository=yascheduler&workflow_filename=release.yml

This PR setup Action as in the documentation https://docs.pypi.org/trusted-publishers/using-a-publisher/