### PR TITLE
Add ability to set server location for Hetzner cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,10 @@ Settings prefix is `hetzner`.
 
   _Default_: `cx52`
 
+- `hetzner_location`
+
+  Location name.
+
 - `hetzner_image_name`
 
   Image name for new nodes.

--- a/yascheduler/clouds/hetzner.py
+++ b/yascheduler/clouds/hetzner.py
@@ -10,6 +10,7 @@ from asyncssh.public_key import SSHKey as ASSHKey
 from hcloud import APIException
 from hcloud import Client as HClient
 from hcloud.images.domain import Image
+from hcloud.locations.domain import Location
 from hcloud.server_types.domain import ServerType
 from hcloud.servers.client import BoundServer
 from hcloud.ssh_keys.domain import SSHKey as HSSHKey
@@ -64,8 +65,9 @@ async def hetzner_create_node(
     create_server = partial(
         client.servers.create,
         name=get_rnd_name("node"),
-        server_type=ServerType(cfg.server_type),
+        server_type=ServerType(name=cfg.server_type),
         image=Image(name=cfg.image_name),
+        location=Location(name=cfg.location) if cfg.location else None,
         ssh_keys=[HSSHKey(id=ssh_key_id, name=get_key_name(key))],
         user_data=cloud_config.render() if cloud_config else None,
     )

--- a/yascheduler/config/cloud.py
+++ b/yascheduler/config/cloud.py
@@ -128,6 +128,7 @@ class ConfigCloudHetzner:
     username: str = _make_default_field("root")
     priority: int = _make_default_field(0)
     server_type: str = _make_default_field("cx52")
+    location: Optional[str] = field(default=None, validator=opt_str_val)
     image_name: str = _make_default_field("debian-11")
     idle_tolerance: int = _make_default_field(120, extra_validators=[validators.ge(1)])
     jump_username: Optional[str] = field(default=None, validator=opt_str_val)
@@ -163,6 +164,7 @@ class ConfigCloudHetzner:
             max_nodes=sec.getint(fmt("max_nodes")),
             username=sec.get(fmt("user")),
             server_type=sec.get(fmt("server_type")),
+            location=sec.get(fmt("location")),
             image_name=sec.get(fmt("image_name")),
             priority=sec.getint(fmt("priority")),
             idle_tolerance=sec.getint(fmt("idle_tolerance")),


### PR DESCRIPTION
The location can be specified in the configuration file. If the location is specified, the server will be created only in that location.