### PR TITLE
Bring your own VM image example

### DIFF
--- a/CLOUD.md
+++ b/CLOUD.md
@@ -1,5 +1,10 @@
 # Cloud Providers
 
+You can pre-build an image with all the engines you need. This can be faster
+than uploading an engine each time/creating an engine when configuring a node.
+There is an example of building such an image at
+[examples/own-vm-image/](examples/own-vm-image/README.md)`.
+
 ## Azure
 
 ### Setup

--- a/examples/own-vm-images/README.md
+++ b/examples/own-vm-images/README.md
@@ -1,0 +1,92 @@
+# Build Your Own OS Image
+
+You can pre-build an image with all the engines you need. This can be faster
+than uploading an engine each time/creating an engine when configuring a node.
+
+The [packer](https://www.hashicorp.com/en/products/packer) utility is used
+to build images. It must be installed beforehand.
+See [documentation](https://developer.hashicorp.com/packer/install).
+
+The details of creation will vary for different targets,
+but the essence will be common.
+
+The main configuration file for `packer` is the `*.pkr.hcl` file.
+It specifies which plugin to use in the `packer` section,
+what to use as OS image source in the `source` section and
+how to build it in the `build` section.
+The contents of this file will be different for different OS and clouds.
+The common parts are in the scripts listed in the `source` section.
+
+## FLEUR Engine on Debian 12 at Hetzner Cloud
+
+In Hetzner Cloud, the OS image is called a "snapshot".
+The snapshot can be used as a base for creating a "server".
+
+You need to create a project in HCloud and create a read and write API key
+in it. Then specify this API key in the `HCLOUD_TOKEN` environment variable.
+For example, `export HCLOUD_TOKEN=“xxxx”`.
+
+The main configuration file for the build is `hcloud-debian-12-fleur.pkr.hcl`.
+Most likely you need to change the `location` and `server_type` in the
+`source` section to match your HCloud project's settings.
+
+There is a list of provision shell scripts in the `build` section.
+The engine build script is located in the `install-fleur.sh` file.
+The rest of the scripts perform common operations to prepare an OS image
+and will not be significantly different for other OS/clouds/engines.
+
+Let's build an image. To do this, install required `packer` plugins:
+
+```sh
+packer init ./hcloud-debian-12-fleur.pkr.hcl
+```
+
+Then run build script:
+
+```sh
+packer build ./hcloud-debian-12-fleur.pkr.hcl
+```
+
+This can take 15 to 20 minutes.
+If everything is successful, the last line will show the image ID. Remember this ID - you will need to specify it in `yascheduler.conf`.
+
+```
+--> hcloud.debian: A snapshot was created: 'fleur-debian-xxxxx' (ID: 123123123)
+```
+
+As a result, we have an OS image (snapshot) with the usual
+Debian 12 with `inpgen` and `fleur` already installed.
+
+Let's configure `yascheduler` to use our OS image.
+Setup `db`, `local` and `remote` sections in `yascheduler.conf` as usual. Add `clouds` and engines sections:
+
+```ini
+[engine.inpgen]
+spawn = inpgen -explicit -inc +all -f aiida.in > shell.out 2> out.error
+check_cmd = ps -eocomm= | grep -q inpgen
+input_files = aiida.in
+output_files = aiida.in inp.xml default.econfig shell.out out out.error scratch struct.xsf
+
+[engine.fleur]
+spawn = fleur -minimalOutput -wtime 360 > shell.out 2> out.error
+check_cmd = ps -eocomm= | grep -q fleur
+input_files = inp.xml
+output_files = inp.xml kpts.xml sym.xml relax.xml shell.out out.error out out.xml FleurInputSchema.xsd FleurOutputSchema.xsd juDFT_times.json cdn1 usage.json
+
+[clouds]
+; Your API key
+hetzner_token = xxx
+; Your preffered server type.
+; The disk should be at least as large as the snapshot.
+hetzner_server_type = cpx21
+; It's best to use the same location as the snapshot.
+; This way servers will be created faster.
+hetzner_location = fsn1
+; OS image ID that you should have memorized earlier.
+; You can always look under Snapshots in HCloud Dashboard.
+hetzner_image_name = 237472643
+```
+
+With this configuration, `yascheduler` will build servers from our
+OS image with pre-installed engines. This way, after spending time once,
+we don't waste time building/loading the engine every time.

--- a/examples/own-vm-images/clean-apt-files.sh
+++ b/examples/own-vm-images/clean-apt-files.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# remove apt files
+
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get -y autopurge
+apt-get -y clean
+
+rm -rf /var/lib/apt/lists/*

--- a/examples/own-vm-images/clean-logs.sh
+++ b/examples/own-vm-images/clean-logs.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# remove logs
+
+journalctl --flush
+journalctl --rotate --vacuum-time=0
+
+find /var/log -type f -exec truncate --size 0 {} \; # truncate system logs
+find /var/log -type f -name '*.[1-9]' -delete # remove archived logs
+find /var/log -type f -name '*.gz' -delete # remove compressed archived logs

--- a/examples/own-vm-images/clean-root.sh
+++ b/examples/own-vm-images/clean-root.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# remove user files
+
+unset HISTFILE
+
+rm -rf /root/.cache
+rm -rf /root/.ssh
+rm -f /root/.bash_history
+rm -f /root/.lesshst
+rm -f /root/.viminfo

--- a/examples/own-vm-images/docker-debian-12-fleur.pkr.hcl
+++ b/examples/own-vm-images/docker-debian-12-fleur.pkr.hcl
@@ -1,0 +1,32 @@
+packer {
+  required_plugins {
+    docker = {
+      source  = "github.com/hashicorp/docker"
+      version = "~> 1.1"
+    }
+  }
+}
+
+source "docker" "debian" {
+  image  = "debian:12"
+  commit = true
+}
+
+build {
+  name = "fleur"
+  sources = [
+    "source.docker.debian"
+  ]
+
+  provisioner "shell" {
+    scripts = [
+      "install-fleur.sh",
+      "clean-apt-files.sh",
+    ]
+  }
+
+  post-processor "docker-tag" {
+    repository = "fleur"
+    tags       = ["debian-12"]
+  }
+}

--- a/examples/own-vm-images/flush-disk.sh
+++ b/examples/own-vm-images/flush-disk.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# must discard the now unused blocks from the disk
+
+dd if=/dev/zero of=/zero bs=4M || true
+sync
+rm -f /zero

--- a/examples/own-vm-images/hcloud-debian-12-fleur.pkr.hcl
+++ b/examples/own-vm-images/hcloud-debian-12-fleur.pkr.hcl
@@ -1,0 +1,68 @@
+packer {
+  required_plugins {
+    hcloud = {
+      source  = "github.com/hetznercloud/hcloud"
+      version = "~> 1.6"
+    }
+  }
+}
+
+variable "hcloud_token" {
+  type      = string
+  sensitive = true
+  default   = "${env("HCLOUD_TOKEN")}"
+}
+
+locals {
+  current_timestamp = "${formatdate("YYYY-MM-DD-hhmm", timestamp())}Z"
+}
+
+source "hcloud" "debian" {
+  token = var.hcloud_token
+
+  image       = "debian-12"
+  location    = "fsn1"
+  server_type = "ccx13" # you need at least 8 Gb of RAM
+  server_name = "fleur-build-${local.current_timestamp}"
+
+  # keep disk small
+  user_data = <<-EOF
+    #cloud-config
+    growpart:
+      mode: "off"
+    resize_rootfs: false
+  EOF
+
+  ssh_username = "root"
+
+  snapshot_name = "fleur-debian-${local.current_timestamp}"
+}
+
+build {
+  sources = ["source.hcloud.debian"]
+
+  provisioner "shell" {
+    inline           = [
+      "cloud-init status --wait --long"
+    ]
+    valid_exit_codes = [0, 2]
+  }
+
+  provisioner "shell" {
+    inline = [
+      "apt-get update",
+    ]
+  }
+
+  provisioner "shell" {
+    scripts = [
+      "install-fleur.sh",
+      "reset-cloud-init.sh",
+      "reset-ssh-host-keys.sh",
+      "clean-apt-files.sh",
+      "clean-logs.sh",
+      "clean-root.sh",
+      "flush-disk.sh",
+    ]
+  }
+}

--- a/examples/own-vm-images/install-fleur.sh
+++ b/examples/own-vm-images/install-fleur.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# build and install fleur and inpgen
+
+set -euxo pipefail
+
+FLEUR_REPO="https://iffgit.fz-juelich.de/fleur/fleur.git"
+FLEUR_VERSION="MaX-R6.2"
+DEPS=(libarpack2 libgomp1 libscalapack-openmpi2.2 openmpi-bin openmpi-common)
+# this will be removed after compilation
+BUILD_DEPS=(build-essential cmake doxygen gfortran git libarpack2-dev libopenblas-dev libopenmpi-dev libscalapack-mpi-dev libxc-dev libxml2-dev)
+BUILD_DEPS_DO_NOT_REMOVE=(python3-minimal)
+WORKDIR=$(mktemp -d)
+
+export DEBIAN_FRONTEND=noninteractive
+export FC=mpifort
+export CXX=mpicxx
+export CC=mpicc
+
+# install deps
+apt-get update
+apt-get -y install "${DEPS[@]}" "${BUILD_DEPS[@]}" "${BUILD_DEPS_DO_NOT_REMOVE[@]}"
+
+# build in ram
+mount -t tmpfs -o size=6G fleur_build "$WORKDIR"
+df -h
+
+# build and install fleur
+git clone --depth 1 --branch "$FLEUR_VERSION" "$FLEUR_REPO" "$WORKDIR"
+pushd "$WORKDIR"
+./configure.sh -libxc TRUE -hdf5 TRUE
+pushd build
+make -j 4
+install -t /usr/local/bin fleur_MPI inpgen
+ln -s /usr/local/bin/fleur_MPI /usr/local/bin/fleur
+popd
+popd
+
+# cleanup
+umount "$WORKDIR"
+rm -rf "$WORKDIR"
+apt-get -y remove "${BUILD_DEPS[@]}"

--- a/examples/own-vm-images/reset-cloud-init.sh
+++ b/examples/own-vm-images/reset-cloud-init.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# reset cloud init state
+
+cloud-init clean --logs --machine-id --seed
+
+rm -rf /run/cloud-init/*
+rm -rf /var/lib/cloud/*

--- a/examples/own-vm-images/reset-ssh-host-keys.sh
+++ b/examples/own-vm-images/reset-ssh-host-keys.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# remove host SSH keys
+
+rm -f /etc/ssh/ssh_host_*_key /etc/ssh/ssh_host_*_key.pub

--- a/examples/submit_fleur_input.py
+++ b/examples/submit_fleur_input.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Submit Fleur task"""
+
+from pathlib import Path
+from time import sleep
+
+from yascheduler import Yascheduler
+
+SI = """
+Si bulk
+&lattice latsys='cF', a0=1.8897269, a=5.43 /
+2
+14 0.125 0.125 0.125
+14 -0.125 -0.125 -0.125
+"""
+
+
+yac = Yascheduler()
+task_id = yac.queue_submit_task(
+    "test inpgen",
+    {
+        "aiida.in": SI,
+    },
+    "inpgen",
+)
+
+while True:
+    task = yac.queue_get_task(task_id)
+    if task and task.get("status") == yac.STATUS_DONE:
+        print(task)
+        break
+    sleep(1)
+
+inpgen_folder = task.get("metadata", {}).get("local_folder")
+assert inpgen_folder
+inp_xml_path = Path(inpgen_folder) / "inp.xml"
+
+task_id = yac.queue_submit_task(
+    "test fleur",
+    {
+        "inp.xml": inp_xml_path.read_text(),
+    },
+    "fleur",
+)
+
+while True:
+    task = yac.queue_get_task(task_id)
+    if task and task.get("status") == yac.STATUS_DONE:
+        print(task)
+        break
+    sleep(1)


### PR DESCRIPTION
An example is added of how to build your own OS image with the right engines in a relatively simple way, so that you don't have to spend time building each time you create a node. This prevents `yascheduler` from turning into a configuration manager, which it is not.

The FLUER engine building in the Hetzner Cloud is used as an example. However, it is not difficult to build an image for another cloud. You'll have to use a different packer configuration, but the engine build scripts shouldn't change.

Also added an example of how to configure yascheduler to use its OS image and the FLEUR engine. Added an example of how to submit a job for the FLEUR engine.