### PR TITLE
Support custom SSH port for nodes

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -46,7 +46,3 @@ jobs:
           ruff check --exit-non-zero-on-fix
 
       - uses: jakebailey/pyright-action@b5d50e5cde6547546a5c4ac92e416a8c2c1a1dfe
-
-      - name: pyupgrade
-        run: |
-          pyupgrade --py39-plus **.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,49 +8,49 @@ name = "yascheduler"
 version = "1.5.1"
 description = """Yet another computing scheduler and cloud orchestration engine"""
 authors = [
-    { name = "Sergei Korolev", email = "knopki@duck.com" },
-    { name = "Andrey Sobolev", email = "as@tilde.pro" },
-    { name = "Evgeny Blokhin", email = "eb@tilde.pro" },
+  { name = "Sergei Korolev", email = "knopki@duck.com" },
+  { name = "Andrey Sobolev", email = "as@tilde.pro" },
+  { name = "Evgeny Blokhin", email = "eb@tilde.pro" },
 ]
 readme = { file = "README.md", content-type = "text/markdown" }
 license = "MIT"
 license-files = ["LICENSE"]
 classifiers = [
-    "Development Status :: 4 - Beta",
-    "Intended Audience :: Science/Research",
-    "Topic :: Scientific/Engineering :: Chemistry",
-    "Topic :: Scientific/Engineering :: Physics",
-    "Topic :: Scientific/Engineering :: Information Analysis",
-    "Topic :: Software Development :: Libraries :: Python Modules",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "Framework :: AiiDA",
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Science/Research",
+  "Topic :: Scientific/Engineering :: Chemistry",
+  "Topic :: Scientific/Engineering :: Physics",
+  "Topic :: Scientific/Engineering :: Information Analysis",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Framework :: AiiDA",
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "aiohttp~=3.8",
-    "asyncssh~=2.11",
-    "asyncstdlib~=3.10",
-    "attrs>=22.2.0",
-    "backoff~=2.1.2",
-    "pg8000~=1.19",
-    "python-daemon~=2.3",
-    "typing-extensions >= 4.2.0; python_version < '3.11'",
+  "aiohttp~=3.8",
+  "asyncssh~=2.11",
+  "asyncstdlib~=3.10",
+  "attrs>=22.2.0",
+  "backoff~=2.1.2",
+  "pg8000~=1.19",
+  "python-daemon~=2.3",
+  "typing-extensions >= 4.2.0; python_version < '3.11'",
 ]
 
 [project.optional-dependencies]
 azure = [
-    "azure-identity~=1.10.0",
-    "azure-mgmt-compute~=27.2.0",
-    "azure-mgmt-network~=20.0.0",
+  "azure-identity~=1.10.0",
+  "azure-mgmt-compute~=27.2.0",
+  "azure-mgmt-network~=20.0.0",
 ]
 hetzner = ["hcloud~=2.0"]
 upcloud = ["upcloud_api~=2.0"]
-dev = ["build", "commitizen", "pyright", "pyupgrade", "ruff", "twine"]
+dev = ["build", "commitizen", "pyright", "ruff", "twine"]
 
 [project.urls]
 Home = "https://github.com/tilde-lab/yascheduler"
@@ -80,8 +80,8 @@ changelog_incremental = true
 [tool.pyright]
 pythonVersion = "3.9"
 executionEnvironments = [
-    { root = "yascheduler/aiida_plugin.py", reportMissingImports = "warning" },
-    { root = "yascheduler/clouds", reportMissingImports = "warning" },
+  { root = "yascheduler/aiida_plugin.py", reportMissingImports = "warning" },
+  { root = "yascheduler/clouds", reportMissingImports = "warning" },
 ]
 
 [tool.ruff]
@@ -90,16 +90,16 @@ target-version = "py39"
 
 [tool.ruff.lint]
 # Enable specific rules
-select = ["E", "F"]
+select = ["E", "F", "UP"]
 # Disable specific rules
 ignore = ["E501"]
 
 [tool.setuptools.package-data]
 "yascheduler.data" = [
-    "schema.sql",
-    "yascheduler.conf",
-    "yascheduler.service",
-    "yascheduler.sh",
+  "schema.sql",
+  "yascheduler.conf",
+  "yascheduler.service",
+  "yascheduler.sh",
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ azure = [
 ]
 hetzner = ["hcloud~=2.0"]
 upcloud = ["upcloud_api~=2.0"]
-dev = ["build", "commitizen", "pyright", "ruff", "twine"]
+dev = ["build", "commitizen", "pyright", "ruff~=0.15.9", "twine"]
 
 [project.urls]
 Home = "https://github.com/tilde-lab/yascheduler"

--- a/yascheduler/clouds/cloud_api.py
+++ b/yascheduler/clouds/cloud_api.py
@@ -113,9 +113,11 @@ class CloudAPI(Generic[TConfigCloud_inv]):
     async def get_cloud_config_data(self) -> PCloudConfig:
         "Common cloud-config"
         engines = self.engines.filter(
-            lambda e: bool(e.platforms)
-            and any(map(self.is_platform_supported, e.platforms))
-            or not e.platforms
+            lambda e: (
+                bool(e.platforms)
+                and any(map(self.is_platform_supported, e.platforms))
+                or not e.platforms
+            )
         )
         pkgs = engines.get_platform_packages()
         return CloudConfig(package_upgrade=True, packages=pkgs)

--- a/yascheduler/clouds/cloud_api_manager.py
+++ b/yascheduler/clouds/cloud_api_manager.py
@@ -173,7 +173,13 @@ class CloudAPIManager:
             await self.db.remove_node(tmp_ip)
             await self.db.commit()
 
-        await self.db.add_node(ip_addr, api.config.username, None, api.name, True)
+        _ = await self.db.add_node(
+            ip_addr=ip_addr,
+            username=api.config.username,
+            port=None,
+            cloud=api.name,
+            enabled=True,
+        )
         await self.db.commit()
         return ip_addr
 

--- a/yascheduler/clouds/upcloud.py
+++ b/yascheduler/clouds/upcloud.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import time
 from concurrent.futures.thread import ThreadPoolExecutor
-from functools import lru_cache
+from functools import cache
 from typing import Optional, cast
 
 from asyncssh.public_key import SSHKey
@@ -17,7 +17,7 @@ from .utils import get_rnd_name
 executor = ThreadPoolExecutor(max_workers=5)
 
 
-@lru_cache(maxsize=None)
+@cache
 def get_client(cfg: ConfigCloudUpcloud) -> CloudManager:
     """Get Upcloud client"""
     client = CloudManager(cfg.login, cfg.password)

--- a/yascheduler/data/schema.sql
+++ b/yascheduler/data/schema.sql
@@ -1,9 +1,10 @@
 CREATE TABLE yascheduler_nodes (
     ip VARCHAR(15) UNIQUE,
+    port INTEGER DEFAULT 22,
+    username VARCHAR(255) DEFAULT 'root',
     ncpus SMALLINT DEFAULT NULL,
     enabled BOOLEAN DEFAULT TRUE,
-    cloud VARCHAR(32) DEFAULT NULL,
-    username VARCHAR(255) DEFAULT 'root'
+    cloud VARCHAR(32) DEFAULT NULL
 );
 
 CREATE TABLE yascheduler_tasks (

--- a/yascheduler/db.py
+++ b/yascheduler/db.py
@@ -34,6 +34,7 @@ class NodeModel:
     enabled: bool = field(default=True)
     cloud: Optional[str] = field(default=None)
     username: str = field(default="root")
+    port: int = field(default=22)
 
 
 @define(frozen=True)
@@ -93,8 +94,12 @@ class DB:
     async def migrate(self) -> None:
         """Migrate database scheme"""
         await self.run(
-            """ALTER TABLE yascheduler_nodes
-            ADD COLUMN IF NOT EXISTS username VARCHAR(255) DEFAULT 'root';"""
+            """
+            ALTER TABLE yascheduler_nodes
+            ADD COLUMN IF NOT EXISTS username VARCHAR(255) DEFAULT 'root';
+            ALTER TABLE yascheduler_nodes
+            ADD COLUMN IF NOT EXISTS port INTEGER DEFAULT 22;
+            """
         )
 
     async def commit(self):
@@ -122,14 +127,14 @@ class DB:
     async def get_all_nodes(self) -> Sequence[NodeModel]:
         """Get all nodes"""
         rows = await self.run(
-            """SELECT ip, ncpus, enabled, cloud, username FROM yascheduler_nodes;"""
+            """SELECT ip, ncpus, enabled, cloud, username, port FROM yascheduler_nodes;"""
         )
         return [NodeModel(*x) for x in (rows or [])]
 
     async def get_enabled_nodes(self) -> Sequence[NodeModel]:
         """Get all enabled nodes"""
         rows = await self.run(
-            """SELECT ip, ncpus, enabled, cloud, username
+            """SELECT ip, ncpus, enabled, cloud, username, port
             FROM yascheduler_nodes WHERE enabled=TRUE;"""
         )
         return [y for y in [NodeModel(*x) for x in (rows or [])] if "." in y.ip]
@@ -137,7 +142,7 @@ class DB:
     async def get_disabled_nodes(self) -> Sequence[NodeModel]:
         """Get all disabled nodes"""
         rows = await self.run(
-            """SELECT ip, ncpus, enabled, cloud, username
+            """SELECT ip, ncpus, enabled, cloud, username, port
             FROM yascheduler_nodes WHERE enabled=FALSE;"""
         )
         return [y for y in [NodeModel(*x) for x in (rows or [])] if "." in y.ip]
@@ -145,7 +150,7 @@ class DB:
     async def get_node(self, ip_addr: str) -> Optional[NodeModel]:
         """Get node by ip"""
         rows = await self.run(
-            """SELECT ip, ncpus, enabled, cloud, username
+            """SELECT ip, ncpus, enabled, cloud, username, port
             FROM yascheduler_nodes
             WHERE ip=:ip;""",
             ip=ip_addr,
@@ -192,22 +197,24 @@ class DB:
         self,
         ip_addr: str,
         username: str,
+        port: int = 22,
         ncpus: Optional[int] = None,
         cloud: Optional[str] = None,
         enabled: bool = False,
     ) -> NodeModel:
         """Add new node"""
         await self.run(
-            """INSERT INTO yascheduler_nodes (ip, ncpus, enabled, cloud, username)
-            VALUES (:ip, :ncpus, :enabled, :cloud, :username);""",
+            """INSERT INTO yascheduler_nodes (ip, ncpus, enabled, cloud, username, port)
+            VALUES (:ip, :ncpus, :enabled, :cloud, :username, :port);""",
             ip=ip_addr,
             ncpus=ncpus,
             cloud=cloud,
             username=username,
             enabled=enabled,
+            port=port,
         )
         return NodeModel(
-            ip_addr, ncpus, enabled=enabled, cloud=cloud, username=username
+            ip_addr, ncpus, enabled=enabled, cloud=cloud, username=username, port=port
         )
 
     async def enable_node(self, ip_addr: str) -> None:

--- a/yascheduler/db.py
+++ b/yascheduler/db.py
@@ -197,12 +197,13 @@ class DB:
         self,
         ip_addr: str,
         username: str,
-        port: int = 22,
+        port: Optional[int] = 22,
         ncpus: Optional[int] = None,
         cloud: Optional[str] = None,
         enabled: bool = False,
     ) -> NodeModel:
         """Add new node"""
+        port = port or 22
         await self.run(
             """INSERT INTO yascheduler_nodes (ip, ncpus, enabled, cloud, username, port)
             VALUES (:ip, :ncpus, :enabled, :cloud, :username, :port);""",
@@ -214,7 +215,12 @@ class DB:
             port=port,
         )
         return NodeModel(
-            ip_addr, ncpus, enabled=enabled, cloud=cloud, username=username, port=port
+            ip_addr,
+            ncpus,
+            enabled=enabled,
+            cloud=cloud,
+            username=username,
+            port=port,
         )
 
     async def enable_node(self, ip_addr: str) -> None:

--- a/yascheduler/remote_machine/remote_machine.py
+++ b/yascheduler/remote_machine/remote_machine.py
@@ -176,6 +176,7 @@ class RemoteMachine:
         host: str,
         username: str,
         client_keys: Optional[Sequence[PurePath]],
+        port: int = 22,
         logger: Optional[logging.Logger] = None,
         connect_timeout: Optional[int] = None,
         data_dir: Optional[PurePath] = None,
@@ -184,7 +185,7 @@ class RemoteMachine:
         jump_host: Optional[str] = None,
         jump_username: Optional[str] = None,
     ) -> Self:
-        logger_name = f"{cls.__name__}:{username}@{host}"
+        logger_name = f"{cls.__name__}:{username}@{host}:{port}"
         if logger:
             log = logger.getChild(logger_name)
         else:
@@ -198,6 +199,7 @@ class RemoteMachine:
         conn_opts = SSHClientConnectionOptions(
             options=DEFAULT_CONN_OPTS,
             host=host,
+            port=port,
             username=username,
             tunnel=jump_host and jump_username and f"{jump_username}@{jump_host}",
             client_keys=client_keys or (),
@@ -209,6 +211,7 @@ class RemoteMachine:
         conn = await asyncssh.connection.connect(
             options=conn_opts,
             host=conn_opts.host,
+            port=conn_opts.port,
             tunnel=conn_opts.tunnel,
         )
 

--- a/yascheduler/scheduler.py
+++ b/yascheduler/scheduler.py
@@ -169,11 +169,11 @@ class Scheduler:
     ) -> TaskModel:
         "Create new task in DB"
         if engine_name not in self.config.engines:
-            raise RuntimeError("Engine %s requested, but not supported" % engine_name)
+            raise RuntimeError(f"Engine {engine_name} requested, but not supported")
 
         for input_file in self.config.engines[engine_name].input_files:
             if input_file not in metadata:
-                raise RuntimeError("Input file %s was not provided" % input_file)
+                raise RuntimeError(f"Input file {input_file} was not provided")
 
         meta_add = [("engine", engine_name)]
         new_meta = dict(list(metadata.items()) + meta_add)
@@ -188,7 +188,7 @@ class Scheduler:
         await self.db.commit()
         if webhook_onsubmit:
             await self.do_task_webhook(task.task_id, new_meta, TaskStatus.TO_DO)
-        self.log.info(":::submitted: %s" % label)
+        self.log.info(f":::submitted: {label}")
         return task
 
     async def upload_task_data(
@@ -216,8 +216,7 @@ class Scheduler:
             await sftp.makedirs(PurePosixPath(remote_dir), exist_ok=True)
         except asyncssh.misc.Error as err:
             self.log.error(
-                "Create %s - SFTPError: %s (%s) (task_id=%s)"
-                % (str(remote_dir), err.reason, err.code, task.task_id)
+                f"Create {str(remote_dir)} - SFTPError: {err.reason} ({err.code}) (task_id={task.task_id})"
             )
             raise err
 
@@ -234,8 +233,7 @@ class Scheduler:
 
                 except asyncssh.misc.Error as err:
                     self.log.error(
-                        "Write %s - SFTPError: %s (%s)"
-                        % (str(r_input_file), err.reason, err.code)
+                        f"Write {str(r_input_file)} - SFTPError: {err.reason} ({err.code})"
                     )
                     raise err
                 except Exception as e:
@@ -249,8 +247,7 @@ class Scheduler:
                         await f.write(task.metadata[input_file])
                 except asyncssh.misc.Error as err:
                     self.log.error(
-                        "Write %s - SFTPError: %s (%s)"
-                        % (str(r_input_file), err.reason, err.code)
+                        f"Write {str(r_input_file)} - SFTPError: {err.reason} ({err.code})"
                     )
                 except Exception as e:
                     self.log.error(f"Error processing file {input_file}: {e}")
@@ -264,8 +261,7 @@ class Scheduler:
     ) -> bool:
         "Run task on remote machine"
         self.log.info(
-            "Submitting task_id=%s %s with %s to %s"
-            % (task.task_id, task.label, engine.name, machine.hostname)
+            f"Submitting task_id={task.task_id} {task.label} with {engine.name} to {machine.hostname}"
         )
         assert task.metadata.get("remote_folder")
         machine.meta.busy = True
@@ -304,7 +300,7 @@ class Scheduler:
             )
             await machine.run_bg(run_cmd, cwd=str(task_dir))
         except Exception as err:
-            self.log.error("SSH spawn cmd error: %s" % err)
+            self.log.error(f"SSH spawn cmd error: {err}")
             raise err
 
         return True
@@ -338,8 +334,9 @@ class Scheduler:
         }
         if free_machines:
             self.log.debug(
-                "Free machines with platform match: %s"
-                % ", ".join(free_machines.keys())
+                "Free machines with platform match: {}".format(
+                    ", ".join(free_machines.keys())
+                )
             )
         for ip, machine in free_machines.items():
             task_m = evolve(task, ip=ip)
@@ -427,8 +424,7 @@ class Scheduler:
             await self.do_task_webhook(task.task_id, new_meta, TaskStatus.DONE)
         await self.db.commit()
         self.log.info(
-            "task_id=%s %s done and saved in %s"
-            % (task.task_id, task.label, store_folder)
+            f"task_id={task.task_id} {task.label} done and saved in {store_folder}"
         )
         self.clouds.mark_task_done(task.task_id)
 
@@ -465,7 +461,7 @@ class Scheduler:
                 self.consume_q,
             ]
             qmsgs = [f"{q.name}: {q.psize()}/{q.qsize()}" for q in queues]
-            self.log.info("QUEUES: %s" % " ".join(qmsgs))
+            self.log.info("QUEUES: {}".format(" ".join(qmsgs)))
             await asleep_until(end_time)
 
     async def connect_machine_producer(
@@ -521,7 +517,7 @@ class Scheduler:
         tasks = await self.db.get_tasks_by_status((TaskStatus.TO_DO,), tlim)
         if tasks:
             ids = [str(t.task_id) for t in tasks]
-            self.log.debug("Want to allocate tasks: %s" % ", ".join(ids))
+            self.log.debug("Want to allocate tasks: {}".format(", ".join(ids)))
         for task in tasks:
             yield UMessage(task.task_id, task)
 
@@ -649,7 +645,9 @@ class Scheduler:
 
     async def start(self):
         self.log.debug(
-            "Available computing engines: %s" % ", ".join(self.config.engines.keys())
+            "Available computing engines: {}".format(
+                ", ".join(self.config.engines.keys())
+            )
         )
 
         self.bg_jobs.add(asyncio.create_task(self.print_stats()))

--- a/yascheduler/scheduler.py
+++ b/yascheduler/scheduler.py
@@ -182,9 +182,7 @@ class Scheduler:
             label, ip_addr=None, status=TaskStatus.TO_DO, metadata=new_meta
         )
         dt_str = datetime.now().strftime("%Y%m%d_%H%M%S")
-        remote_folder = self.config.remote.tasks_dir / "{}_{}".format(
-            dt_str, task.task_id
-        )
+        remote_folder = self.config.remote.tasks_dir / f"{dt_str}_{task.task_id}"
         new_meta.update({"remote_folder": str(remote_folder)})
         await self.db.update_task_meta(task.task_id, new_meta)
         await self.db.commit()
@@ -320,9 +318,7 @@ class Scheduler:
         )
         if engine is None:
             self.log.warning(
-                "Unsupported engine '{}' for task_id={}".format(
-                    engine_name, task.task_id
-                )
+                f"Unsupported engine '{engine_name}' for task_id={task.task_id}"
             )
             await self.db.set_task_error(
                 task.task_id, metadata=task.metadata, error="unsupported engine"

--- a/yascheduler/scheduler.py
+++ b/yascheduler/scheduler.py
@@ -201,19 +201,19 @@ class Scheduler:
         input_files: Sequence[str],
     ) -> bool:
         "Upload task data to remote machine"
-        
+
         def safe_b64decode(b64_data: str | bytes) -> bytes:
             """Decodes base64 data, adding padding if necessary and stripping whitespace"""
             if isinstance(b64_data, bytes):
                 # bytes to str
-                b64_data = b64_data.decode() 
-            b64_data = b64_data.strip().replace('\n', '').replace(' ', '')
+                b64_data = b64_data.decode()
+            b64_data = b64_data.strip().replace("\n", "").replace(" ", "")
             # if len(b64_data) % 4 != 0
             missing_padding = len(b64_data) % 4
             if missing_padding:
-                b64_data += '=' * (4 - missing_padding)
+                b64_data += "=" * (4 - missing_padding)
             return base64.b64decode(b64_data)
-        
+
         try:
             await sftp.makedirs(PurePosixPath(remote_dir), exist_ok=True)
         except asyncssh.misc.Error as err:
@@ -225,7 +225,7 @@ class Scheduler:
 
         for input_file in input_files:
             r_input_file = remote_dir / input_file
-            if input_file == 'fort.9':
+            if input_file == "fort.9":
                 try:
                     b64_data = task.metadata[input_file]
 
@@ -241,13 +241,13 @@ class Scheduler:
                     )
                     raise err
                 except Exception as e:
-                    self.log.error(
-                        f"Error processing file {input_file}: {e}"
-                    )
+                    self.log.error(f"Error processing file {input_file}: {e}")
             # if not binary
             else:
                 try:
-                    async with sftp.open(r_input_file.as_posix(), pflags_or_mode="w") as f:
+                    async with sftp.open(
+                        r_input_file.as_posix(), pflags_or_mode="w"
+                    ) as f:
                         await f.write(task.metadata[input_file])
                 except asyncssh.misc.Error as err:
                     self.log.error(
@@ -255,9 +255,7 @@ class Scheduler:
                         % (str(r_input_file), err.reason, err.code)
                     )
                 except Exception as e:
-                    self.log.error(
-                        f"Error processing file {input_file}: {e}"
-                    )
+                    self.log.error(f"Error processing file {input_file}: {e}")
         return True
 
     async def start_task_on_machine(

--- a/yascheduler/scheduler.py
+++ b/yascheduler/scheduler.py
@@ -511,6 +511,7 @@ class Scheduler:
                 connect_timeout=10,
                 jump_username=jump_username,
                 jump_host=jump_host,
+                port=node.port,
             )
         except asyncssh.misc.Error as err:
             self.log.error(f"Can't connect to machine with error: {err}")

--- a/yascheduler/scheduler.py
+++ b/yascheduler/scheduler.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import asyncio
+import base64
 import logging
 from asyncio.locks import Event, Semaphore
 from collections import Counter
@@ -9,7 +10,6 @@ from datetime import datetime, timedelta
 from functools import partial
 from pathlib import Path, PurePath, PurePosixPath
 from typing import Any, Optional, Union
-import base64
 
 import aiohttp
 import asyncssh
@@ -202,7 +202,7 @@ class Scheduler:
     ) -> bool:
         "Upload task data to remote machine"
 
-        def safe_b64decode(b64_data: str | bytes) -> bytes:
+        def safe_b64decode(b64_data: Union[str, bytes]) -> bytes:
             """Decodes base64 data, adding padding if necessary and stripping whitespace"""
             if isinstance(b64_data, bytes):
                 # bytes to str

--- a/yascheduler/utils.py
+++ b/yascheduler/utils.py
@@ -392,9 +392,7 @@ async def manage_node():
         for task_id in task_ids:
             await db.update_task_status(task_id, TaskStatus.DONE)
             print(
-                "An associated task {} at {} is now marked done!".format(
-                    task_id, args.host
-                )
+                f"An associated task {task_id} at {args.host} is now marked done!"
             )
 
         await db.remove_node(args.host)

--- a/yascheduler/utils.py
+++ b/yascheduler/utils.py
@@ -311,7 +311,7 @@ async def show_nodes():
     tasks = await db.get_tasks_by_status(statuses=[TaskStatus.RUNNING])
     nodes = await db.get_all_nodes()
     for node in nodes:
-        tmpl = "ip={ip} ncpus={ncpus} enabled={enabled} occupied_by={occ} (task_id={tid}) {cloud}"
+        tmpl = "ip={ip}{port} ncpus={ncpus} enabled={enabled} occupied_by={occ} (task_id={tid}) {cloud}"
         node_tasks = list(filter(lambda x: x.ip == node.ip, tasks))
         node_label = "-"
         task_id = "-"
@@ -320,6 +320,7 @@ async def show_nodes():
             task_id = x.task_id
         msg = tmpl.format(
             ip=node.ip,
+            port=f":{node.port}" if node.port != 22 else "",
             ncpus=node.ncpus or "MAX",
             enabled=node.enabled,
             occ=node_label,
@@ -332,7 +333,7 @@ async def show_nodes():
 @to_sync
 async def manage_node():
     parser = argparse.ArgumentParser(description="Add nodes to yascheduler daemon")
-    parser.add_argument("host", help="[user@]IP[~ncpus]")
+    parser.add_argument("host", help="[user@]IP[:port][~ncpus]")
     parser.add_argument(
         "--skip-setup",
         required=False,
@@ -366,12 +367,16 @@ async def manage_node():
     db = await DB.create(config.db)
 
     ncpus = None
+    port = 22
     username = config.remote.username
     if "@" in args.host:
         username, args.host = args.host.split("@")
     if "~" in args.host:
         args.host, ncpus = args.host.split("~")
         ncpus = int(ncpus)
+    if ":" in args.host:
+        args.host, port_str = args.host.rsplit(":", 1)
+        port = int(port_str)
 
     already_there = await db.has_node(args.host)
     if already_there and not args.remove_hard and not args.remove_soft:
@@ -417,17 +422,20 @@ async def manage_node():
         username=username,
         client_keys=config.local.get_private_keys(),
         engines_dir=config.remote.engines_dir,
+        port=port,
     )
 
     if not args.skip_setup:
         print("Setup host...")
         await machine.setup_node(config.engines)
 
-    await db.add_node(ip_addr=args.host, username=username, ncpus=ncpus, enabled=True)
+    await db.add_node(
+        ip_addr=args.host, port=port, username=username, ncpus=ncpus, enabled=True
+    )
     await db.commit()
     await db.close()
 
-    print(f"Added host to yascheduler: {args.host}")
+    print(f"Added host to yascheduler: {args.host}:{port}")
 
 
 def daemonize(log_file: Optional[Union[str, Path]] = None):

--- a/yascheduler/utils.py
+++ b/yascheduler/utils.py
@@ -55,7 +55,7 @@ async def submit():
 
     engine = yac.config.engines.get(script_params["ENGINE"])
     if not engine:
-        raise ValueError("Engine %s is not supported" % script_params["ENGINE"])
+        raise ValueError("Engine {} is not supported".format(script_params["ENGINE"]))
 
     for input_file in engine.input_files:
         try:
@@ -135,8 +135,7 @@ async def check_status():  # noqa: C901
             ssh_user = ssh_user or config.remote.username
             print(
                 "." * 50
-                + "ID%s %s at %s@%s:%s:%s"
-                % (
+                + "ID{} {} at {}@{}:{}:{}".format(
                     task.task_id,
                     task.label,
                     ssh_user,
@@ -200,7 +199,7 @@ async def check_status():  # noqa: C901
                             + "E={:12f}".format(calc.info["optgeom"][n][4] or nan)
                             + " eV"
                             + "  "
-                            + "(%s)" % ncycles
+                            + f"({ncycles})"
                             + "\n"
                         )
                 print(output_lines)
@@ -259,7 +258,7 @@ def _init_systemd(install_path: Path):
     unit_file = Path("/lib/systemd/system/yascheduler.service")
     if not unit_file.is_file():
         if not os.access(unit_file, os.W_OK):
-            print("Error: cannot write to %s" % unit_file)
+            print(f"Error: cannot write to {unit_file}")
             return
         daemon_file = install_path / "daemon_systemd.py"
         systemd_script = src_unit_file.read_text("utf-8").replace(
@@ -276,7 +275,7 @@ def _init_sysv(install_path: Path):
     startup_file = Path("/etc/init.d/yascheduler")
     if not startup_file.is_file():
         if not os.access(startup_file, os.W_OK):
-            print("Error: cannot write to %s" % startup_file)
+            print(f"Error: cannot write to {startup_file}")
             return
 
         daemon_file = install_path / "daemon_sysv.py"
@@ -391,9 +390,7 @@ async def manage_node():
         task_ids = await db.get_task_ids_by_ip_and_status(args.host, TaskStatus.RUNNING)
         for task_id in task_ids:
             await db.update_task_status(task_id, TaskStatus.DONE)
-            print(
-                f"An associated task {task_id} at {args.host} is now marked done!"
-            )
+            print(f"An associated task {task_id} at {args.host} is now marked done!")
 
         await db.remove_node(args.host)
         await db.commit()


### PR DESCRIPTION
Add ability to connect to nodes on non-standard SSH ports.
- DB: new port column in yascheduler_nodes (default 22), migration for existing installations
- CLI: node command now accepts [user@]IP[:port][~ncpus] format
- RemoteMachine and scheduler pass port through to asyncssh
- show_nodes displays port when non-default
- Minor ruff formatting fixes