### PR TITLE
View respects `engine.output_files` instead of hardcoded `OUTPUT`

### DIFF
--- a/yascheduler/utils.py
+++ b/yascheduler/utils.py
@@ -149,7 +149,13 @@ async def check_status():  # noqa: C901
                 username=ssh_user,
                 client_keys=config.local.get_private_keys(),
             )
-            r_output = machine.path(task.metadata["remote_folder"]) / "OUTPUT"
+            engine_name = task.metadata.get("engine")
+            engine = config.engines.get(engine_name) if engine_name else None
+            if engine and engine.output_files:
+                output_file = engine.output_files[0]
+            else:
+                output_file = "OUTPUT"
+            r_output = machine.path(task.metadata["remote_folder"]) / output_file
             result = await machine.run(f"tail -n15 {machine.quote(str(r_output))}")
             if result.returncode:
                 print("OUTDATED TASK, SKIPPING")
@@ -161,7 +167,9 @@ async def check_status():  # noqa: C901
                     config.local.data_dir, "local_calc_snippet.tmp"
                 )
                 try:
-                    r_output = machine.path(task.metadata["remote_folder"]) / "OUTPUT"
+                    r_output = (
+                        machine.path(task.metadata["remote_folder"]) / output_file
+                    )
                     async with machine.sftp() as sftp:
                         await sftp.get([str(r_output)], local_calc_snippet)
                 except OSError:


### PR DESCRIPTION
Closes #156

## Why

`yascheduler -v` ran `tail -n15 OUTPUT` against every running task's remote folder, regardless of which engine produced it. That works for pcrystal, whose `output_files` happens to contain `OUTPUT`, but every other configured engine has its own filename and the tail target was silently nonexistent.

## What

`utils.py` now resolves the engine for the task being viewed via `task.metadata[\"engine\"]` (already stored by the scheduler in `create_new_task`) and uses the first entry of `engine.output_files` as the file to tail. The convergence sftp download below it shares the same lookup so `-v -o` keeps working consistently.

`OUTPUT` is kept as the fallback when the engine cannot be resolved (e.g. an old task whose engine was since removed from config), so today's behaviour is preserved for that edge case.

## Verification

```
ruff format --check --diff yascheduler/utils.py
ruff check yascheduler/utils.py
```

Both clean.