### PR TITLE
fix: deduplicate Vultr SSH keys by public key, not fingerprint

### DIFF
--- a/yascheduler/clouds/vultr.py
+++ b/yascheduler/clouds/vultr.py
@@ -94,6 +94,11 @@ async def get_ssh_key_id(client: VultrClient, key: ASSHKey) -> str:
 
     data = await client.request("GET", "/ssh-keys?per_page=500")
     for existing in data.get("ssh_keys", []):
+        # Match by public key — Vultr API always returns this field
+        existing_pub = existing.get("ssh_key", "")
+        if existing_pub and existing_pub.strip() == pub_key.strip():
+            return cast(str, existing["id"])
+        # Fallback by fingerprint (in case Vultr returns it in the future)
         existing_fp = existing.get("fingerprint", "")
         if existing_fp and existing_fp.lower() == fingerprint.lower():
             return cast(str, existing["id"])


### PR DESCRIPTION
Vultr API GET /ssh-keys does not return the 'fingerprint' field, so the existing fingerprint-based comparison always missed and created a duplicate key on every instance launch. Match by the 'ssh_key' (public key) field instead, which Vultr reliably returns. Keep fingerprint as a fallback.